### PR TITLE
Updated flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ a.out
 /*.trace
 result/
 result
+result*

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "ancmp": {
       "flake": false,
       "locked": {
-        "lastModified": 1745961887,
-        "narHash": "sha256-9AlCZSTmGOjljcwOqduHKkcs2vih2Hs8sgQrbbqMxYU=",
+        "lastModified": 1746002190,
+        "narHash": "sha256-W570A84RKRSiR+p7bOAeOKmCOWqHI1+QAE9nmCVZ1uI=",
         "owner": "MFDGaming",
         "repo": "ancmp",
-        "rev": "da9c563b053d51d8a73208c2bda534054b50bb0f",
+        "rev": "1d236e865feeef7c6b0af3a3037403584c1ef707",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "ancmp": {
       "flake": false,
       "locked": {
-        "lastModified": 1746002190,
-        "narHash": "sha256-W570A84RKRSiR+p7bOAeOKmCOWqHI1+QAE9nmCVZ1uI=",
+        "lastModified": 1746108894,
+        "narHash": "sha256-yjU8iK/V3B7BD1QZsyIueDwQ/91zkEEQep682cXFjpw=",
         "owner": "MFDGaming",
         "repo": "ancmp",
-        "rev": "1d236e865feeef7c6b0af3a3037403584c1ef707",
+        "rev": "c00193035bf8fb6bc0800c069f7b9e7509ed410a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
* b8c0890c65bd493b078c64fb99f584e2ede354f8 - Coinciding with e62ba7e8ea13cc054e8d3ee81a6ebf7510987f69, flake input `ancmp` has been updated

```
$ nix flake update                                                                                                                          
warning: updating lock file '/home/tumble/Documents/git/tumble/Ninecraft/flake.lock':
• Updated input 'ancmp':
    'github:MFDGaming/ancmp/da9c563b053d51d8a73208c2bda534054b50bb0f' (2025-04-29)
  → 'github:MFDGaming/ancmp/1d236e865feeef7c6b0af3a3037403584c1ef707' (2025-04-30)
warning: Git tree '/home/tumble/Documents/git/tumble/Ninecraft' is dirty
```

3c160ad90771f96725831481b35bad6d898838b0  fixes #33
Fixes #33 