### PR TITLE
Less wrapping

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -61,11 +61,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713543440,
-        "narHash": "sha256-lnzZQYG0+EXl/6NkGpyIz+FEOc/DSEG57AP1VsdeNrM=",
+        "lastModified": 1751696036,
+        "narHash": "sha256-hXq4IOgSdAAaF/9q/2U8TBDL7aXZyQmtq4wl6USZjKo=",
         "owner": "nix-community",
         "repo": "nixGL",
-        "rev": "310f8e49a149e4c9ea52f1adf70cdc768ec53f8a",
+        "rev": "d47b0db35dfa693c10f7c378043dcc6121d3f4ec",
         "type": "github"
       },
       "original": {
@@ -76,11 +76,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750506804,
-        "narHash": "sha256-VLFNc4egNjovYVxDGyBYTrvVCgDYgENp5bVi9fPTDYc=",
+        "lastModified": 1751792365,
+        "narHash": "sha256-J1kI6oAj25IG4EdVlg2hQz8NZTBNYvIS0l4wpr9KcUo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4206c4cb56751df534751b058295ea61357bbbaa",
+        "rev": "1fd8bada0b6117e6c7eb54aad5813023eed37ccb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -46,13 +46,22 @@
         (import ./nix/pkgs {
           inherit pkgs;
           internal_overrides = ./internal_overrides;
-          inherit glad ancmp stb;
+          inherit glad stb ancmp;
+          # ancmp = ./ancmp;
         })
         // {
           default = packages.ninecraft;
         };
+      apps = {
+        extract = {
+          type = "app";
+          program = "${pkgs.callPackage ./nix/pkgs/extract.nix {}}/bin/ninecraft-extract";
+        };
+      };
       formatter = pkgs.alejandra;
-      devShell = pkgs.callPackage ./nix/shell.nix;
+      devShell = pkgs.callPackage ./nix/shell.nix {
+        inherit (packages) ninecraft ninecraft-nixgl;
+      };
     })
     // {
       nixosModule = {pkgs, ...}: {

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -43,12 +43,11 @@
   }),
   ninecraft-desktop-entry ? (pkgs.callPackage ./desktop.nix {}),
 }: rec {
-  extract = pkgs.callPackage ./extract.nix {};
   ninecraft = pkgs.pkgsi686Linux.callPackage ./ninecraft.nix {
-    ninecraft-extract = extract;
-    inherit internal_overrides glad ancmp stb ninecraft-desktop-entry;
+    inherit internal_overrides glad stb ninecraft-desktop-entry ancmp;
   };
   ninecraft-nixgl = pkgs.callPackage ./ninecraft-nixgl.nix {
     inherit ninecraft;
   };
+  inherit internal_overrides;
 }

--- a/nix/pkgs/desktop.nix
+++ b/nix/pkgs/desktop.nix
@@ -1,13 +1,15 @@
 {
   makeDesktopItem,
   icon ? "applications-games",
+  homeDir ? "~/.local/share/ninecraft",
+  gameDir ? "~/.local/share/ninecraft",
   ...
 }:
 makeDesktopItem {
   desktopName = "Ninecraft";
   name = "ninecraft";
   inherit icon;
-  exec = "ninecraft";
+  exec = "ninecraft --home \"${homeDir}\" --game \"${gameDir}\"";
   categories = [
     "Game"
   ];


### PR DESCRIPTION
* Improved use of the derivation
* integrated the desktop file into the package
* removd the wapper script that sets up the folder as its built into ninecraft now
* added `ninecraft-extract` into the package

## todo
* expose ninecraft extraxct as a `nix run`
* some how re implement the downloading a versions (or just scrap all together)
* figure how what to do for versions anyway, like maybe have a command that automatically extracts it into the decided upon game dir
* also figure out internal_overides