### PR TITLE
Hotfix/flake root

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1753250450,
-        "narHash": "sha256-i+CQV2rPmP8wHxj0aq4siYyohHwVlsh40kV89f3nw1s=",
+        "lastModified": 1754214453,
+        "narHash": "sha256-Q/I2xJn/j1wpkGhWkQnm20nShYnG7TI99foDBpXm1SY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fc02ee70efb805d3b2865908a13ddd4474557ecf",
+        "rev": "5b09dc45f24cf32316283e62aec81ffee3c3e376",
         "type": "github"
       },
       "original": {

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -41,6 +41,7 @@
     rev = "main";
     hash = lib.getHash name;
   }),
+  flakeRoot?../..,
   ninecraft-extract ? ../../tools/extract.sh,
 }: rec {
   fetchApk = pkgs.callPackage ./fetchApk.nix {};


### PR DESCRIPTION
Fixes  error that appears in nix
```
error: function 'anonymous lambda' called with unexpected argument 'flakeRoot'
       at /nix/store/dng3c0v4867ld0q4hl1jcji9bc77m4hz-source/nix/pkgs/default.nix:1:1:
```