### PR TITLE
PinePhone Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ result/
 result
 result*
 /docker/run/ninecraft
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,6 @@ a.out
 result/
 result
 result*
+!/docker/build
 /docker/run/ninecraft
 /.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-build/
+build*/
 buil/
 build2/
 build-arm/

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ a.out
 result/
 result
 result*
+/docker/run/ninecraft

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,23 +1,38 @@
 cmake_minimum_required(VERSION 3.1)
 project(ninecraft)
 
-include_directories(${PROJECT_SOURCE_DIR}/stb)
+# Dependencies
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}/stb")
+option(USE_SYSTEM_DEPENDENCIES "Use System Dependencies For Common Libraries" FALSE)
+if(USE_SYSTEM_DEPENDENCIES)
+    # SDL
+    find_package(SDL2 REQUIRED)
+    # ZLib
+    find_package(ZLIB REQUIRED)
+    add_library(zlibstatic ALIAS ZLIB::ZLIB)
+else()
+    # SDL
+    SET(SDL_STATIC ON CACHE BOOL "Enable SDL_STATIC" FORCE)
+    SET(SDL_SHARED OFF CACHE BOOL "Disable SDL_SHARED" FORCE)
+    SET(SDL_MMX OFF CACHE BOOL "Disable SDL_MMX" FORCE)
+    SET(SDL_SSE OFF CACHE BOOL "Disable SDL_SSE" FORCE)
+    SET(SDL_SSE2 OFF CACHE BOOL "Disable SDL_SSE2" FORCE)
+    SET(SDL_SSE3 OFF CACHE BOOL "Disable SDL_SSE3" FORCE)
+    SET(SDL_SSEMATH OFF CACHE BOOL "Disable SDL_SSEMATH" FORCE)
+    SET(SDL_3DNOW OFF CACHE BOOL "Disable SDL_3DNOW" FORCE)
+    SET(SDL_TEST OFF CACHE BOOL "Disable SDL_TEST" FORCE)
+    SET(SDL_TESTS OFF CACHE BOOL "Disable SDL_TESTS" FORCE)
+    add_subdirectory(SDL)
 
-SET(SDL_STATIC ON CACHE BOOL "Enable SDL_STATIC" FORCE)
-SET(SDL_SHARED OFF CACHE BOOL "Disable SDL_SHARED" FORCE)
-SET(SDL_MMX OFF CACHE BOOL "Disable SDL_MMX" FORCE)
-SET(SDL_SSE OFF CACHE BOOL "Disable SDL_SSE" FORCE)
-SET(SDL_SSE2 OFF CACHE BOOL "Disable SDL_SSE2" FORCE)
-SET(SDL_SSE3 OFF CACHE BOOL "Disable SDL_SSE3" FORCE)
-SET(SDL_SSEMATH OFF CACHE BOOL "Disable SDL_SSEMATH" FORCE)
-SET(SDL_3DNOW OFF CACHE BOOL "Disable SDL_3DNOW" FORCE)
-SET(SDL_TEST OFF CACHE BOOL "Disable SDL_TEST" FORCE)
-SET(SDL_TESTS OFF CACHE BOOL "Disable SDL_TESTS" FORCE)
+    # ZLib
+    add_subdirectory(zlib)
+endif()
 
+# OpenGL
 add_subdirectory(glad/cmake)
-glad_add_library(glad REPRODUCIBLE LOADER API egl=1.5 gl:compatibility=2.0)
-add_subdirectory(zlib)
+glad_add_library(glad REPRODUCIBLE LOADER API gl:compatibility=2.0)
+
+# Build
 add_subdirectory(ancmp)
 add_subdirectory(anjni)
-add_subdirectory(SDL)
 add_subdirectory(ninecraft)

--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ git clone --recursive http://github.com/MCPI-Revival/Ninecraft.git
 cd Ninecraft
 make build-arm
 ```
+### postmarketOS (Docker)
+```sh
+git clone --recursive https://github.com/MCPI-Revival/Ninecraft.git
+cd Ninecraft/docker
+./build.sh <i686 or arm>
+DIR="$(pwd)"
+cd <Extracted APK>
+"${DIR}/install.sh" <i686 or arm>
+```
 
 ## Before running for the first time
 ```

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -22,6 +22,7 @@ BUILD="build-docker-${ARCH}"
 mkdir -p "${ROOT}/${BUILD}"
 docker run \
     --rm \
+    --network none \
     --volume "${ROOT}:${DATA}" \
     --workdir "${DATA}/${BUILD}" \
     "ninecraft-build-${ARCH}" \

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -e
+cd "$(dirname "$0")"
+
+# Arguments
+ARCH="$1"
+
+# Prepare Build Environment
+./prepare.sh build "${ARCH}"
+
+# Build
+ROOT="$(cd ../ && pwd)"
+mkdir -p "${ROOT}/build"
+docker run \
+    --volume "${ROOT}:/data" \
+    --user "$(id -u):$(id -g)" \
+    --rm \
+    "ninecraft-build-${ARCH}" \
+    sh -c 'cd /data/build && cmake -DUSE_SYSTEM_DEPENDENCIES=ON .. && cmake --build .'
+
+# Package
+cp "${ROOT}/build/ninecraft/ninecraft" run
+./prepare.sh run "${ARCH}"

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -11,14 +11,16 @@ ARCH="$1"
 
 # Build
 ROOT="$(cd ../ && pwd)"
-mkdir -p "${ROOT}/build"
+BUILD="build-docker-${ARCH}"
+mkdir -p "${ROOT}/${BUILD}"
 docker run \
     --volume "${ROOT}:/data" \
     --user "$(id -u):$(id -g)" \
     --rm \
+    --workdir "/data/${BUILD}" \
     "ninecraft-build-${ARCH}" \
-    sh -c 'cd /data/build && cmake -DUSE_SYSTEM_DEPENDENCIES=ON .. && cmake --build .'
+    sh -c 'cmake -DUSE_SYSTEM_DEPENDENCIES=ON .. && cmake --build .'
 
 # Package
-cp "${ROOT}/build/ninecraft/ninecraft" run
+cp "${ROOT}/${BUILD}/ninecraft/ninecraft" run
 ./prepare.sh run "${ARCH}"

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,27 +1,36 @@
 #!/bin/sh
 
 set -e
+
+# Prepare
 cd "$(dirname "$0")"
+. ./common.sh
 
 # Arguments
 ARCH="$1"
+validate_arch
 
 # Prepare Build Environment
+info 'Creating Build Environment...'
 ./prepare.sh build "${ARCH}"
 
 # Build
+info 'Building Ninecraft...'
 ROOT="$(cd ../ && pwd)"
 DATA='/data'
 BUILD="build-docker-${ARCH}"
 mkdir -p "${ROOT}/${BUILD}"
 docker run \
-    --volume "${ROOT}:${DATA}" \
-    --user "$(id -u):$(id -g)" \
     --rm \
+    --volume "${ROOT}:${DATA}" \
     --workdir "${DATA}/${BUILD}" \
     "ninecraft-build-${ARCH}" \
     sh -c 'cmake -DUSE_SYSTEM_DEPENDENCIES=ON .. && cmake --build .'
 
 # Package
-cp "${ROOT}/${BUILD}/ninecraft/ninecraft" run
+info 'Creating Final Container...'
+FILE="${ROOT}/${BUILD}/ninecraft/ninecraft"
+require_file "${FILE}"
+cp "${FILE}" run
 ./prepare.sh run "${ARCH}"
+info 'Done!'

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -11,13 +11,14 @@ ARCH="$1"
 
 # Build
 ROOT="$(cd ../ && pwd)"
+DATA='/data'
 BUILD="build-docker-${ARCH}"
 mkdir -p "${ROOT}/${BUILD}"
 docker run \
-    --volume "${ROOT}:/data" \
+    --volume "${ROOT}:${DATA}" \
     --user "$(id -u):$(id -g)" \
     --rm \
-    --workdir "/data/${BUILD}" \
+    --workdir "${DATA}/${BUILD}" \
     "ninecraft-build-${ARCH}" \
     sh -c 'cmake -DUSE_SYSTEM_DEPENDENCIES=ON .. && cmake --build .'
 

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1
+# check=error=true;skip=InvalidDefaultArgInFrom
+
+# Base Container
+ARG CONTAINER_PREFIX
+ARG VERSION
+FROM ${CONTAINER_PREFIX}buildpack-deps:${VERSION}
+
+# Install Dependencies
+RUN \
+    apt-get update && \
+    apt-get remove -y make && \
+    apt-get install -y --no-install-recommends \
+        gcc g++ \
+        gdb \
+        cmake \
+        ninja-build \
+        zlib1g-dev \
+        libsdl2-dev \
+        python3-jinja2 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Configure CMake
+ENV CMAKE_GENERATOR=Ninja
+
+# Setup User
+ARG USER_ID
+ARG GROUP_ID
+RUN \
+    groupadd --non-unique --gid "${GROUP_ID}" main && \
+    useradd --non-unique --create-home --uid "${USER_ID}" --gid "${GROUP_ID}" user
+USER user

--- a/docker/common.sh
+++ b/docker/common.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# Logging
+error() {
+    echo "ERROR:" "$@"
+    exit 1
+}
+info() {
+    echo "INFO:" "$@"
+}
+
+# Check If File Exists
+require_file() {
+    FILE="$1"
+    if [ ! -e "${FILE}" ]; then
+        error "Missing File: ${FILE}"
+    fi
+}
+
+# Detect Architecture
+validate_arch() {
+    case "${ARCH}" in
+        i686)
+            PLATFORM='linux/386'
+            CONTAINER_PREFIX='i386/'
+            ANDROID_ARCH='x86'
+            ;;
+        arm)
+            PLATFORM='linux/arm/v7'
+            CONTAINER_PREFIX='arm32v7/'
+            ANDROID_ARCH='armeabi-v7a'
+            ;;
+        *)
+            error "Unsupported Architecture: ${ARCH}"
+            ;;
+    esac
+}

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+set -e
+
+# Constants
+ID='io.github.mfdgaming.Ninecraft'
+
+# Arguments
+ARCH="$1"
+
+# Paths
+APK_ROOT="$(pwd)"
+SRC_ROOT="$(dirname "$0")"
+DATA_ROOT="${HOME}/.local/share"
+
+# Copy Icon
+ICON="${DATA_ROOT}/icons/hicolor/512x512/apps/${ID}.png"
+cp "${APK_ROOT}/res/drawable/iconx.png" "${ICON}"
+
+# Generate Desktop Entry
+APPS="${DATA_ROOT}/applications"
+cat > "${APPS}/${ID}.desktop" <<EOF
+[Desktop Entry]
+Name=Ninecraft
+Comment=An MCPE Launcher
+Icon=${ICON}
+Path=${APK_ROOT}
+Exec=${SRC_ROOT}/run.sh ${ARCH}
+Type=Application
+Categories=Game;
+Terminal=false
+StartupNotify=false
+StartupWMClass=ninecraft
+EOF
+update-desktop-database "${APPS}"

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -18,15 +18,17 @@ validate_arch
 
 # Generate Launcher Script
 info 'Creating Launcher...'
-LINK="${HOME}/.local/bin/${NAME}"
-LAUNCHER="${LINK}-${ARCH}"
-cat > "${LAUNCHER}" <<EOF
+BIN_DIR="${HOME}/.local/bin"
+mkdir -p "${BIN_DIR}"
+SHORT_BIN_PATH="${BIN_DIR}/${NAME}"
+LONG_BIN_PATH="${SHORT_BIN_PATH}-${ARCH}"
+cat > "${LONG_BIN_PATH}" <<EOF
 #!/bin/sh
 set -e
 exec "${SRC_ROOT}/run.sh" "${ARCH}"
 EOF
-chmod +x "${LAUNCHER}"
-ln --symbolic --force "${LAUNCHER}" "${LINK}"
+chmod +x "${LONG_BIN_PATH}"
+ln -sf "${LONG_BIN_PATH}" "${SHORT_BIN_PATH}"
 
 # Copy Icon
 ICON_SRC="${APK_ROOT}/res/drawable/iconx.png"
@@ -35,23 +37,26 @@ if [ ! -f "${ICON_SRC}" ]; then
     exit 0
 fi
 info 'Copying Icon...'
-ICON_DST="${DATA_ROOT}/icons/hicolor/512x512/apps/${ID}.png"
+ICON_DIR="${DATA_ROOT}/icons/hicolor/512x512/apps"
+mkdir -p "${ICON_DIR}"
+ICON_DST="${ICON_DIR}/${ID}.png"
 cp "${ICON_SRC}" "${ICON_DST}"
 
 # Generate Desktop Entry
 info 'Creating Desktop Entry...'
-APPS="${DATA_ROOT}/applications"
-cat > "${APPS}/${ID}.desktop" <<EOF
+APPS_DIR="${DATA_ROOT}/applications"
+mkdir -p "${APPS_DIR}"
+cat > "${APPS_DIR}/${ID}.desktop" <<EOF
 [Desktop Entry]
 Name=Ninecraft
 Comment=An MCPE Launcher
 Icon=${ICON_DST}
 Path=${APK_ROOT}
-Exec=${LAUNCHER}
+Exec=${LONG_BIN_PATH}
 Type=Application
 Categories=Game;
 Terminal=false
 StartupNotify=false
 StartupWMClass=ninecraft
 EOF
-update-desktop-database "${APPS}"
+update-desktop-database "${APPS_DIR}"

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -4,6 +4,7 @@ set -e
 
 # Constants
 ID='io.github.mfdgaming.Ninecraft'
+NAME='ninecraft'
 
 # Paths
 DATA_ROOT="${HOME}/.local/share"
@@ -15,10 +16,27 @@ SRC_ROOT="$(dirname "$0")"
 ARCH="$1"
 validate_arch
 
+# Generate Launcher Script
+info 'Creating Launcher...'
+LINK="${HOME}/.local/bin/${NAME}"
+LAUNCHER="${LINK}-${ARCH}"
+cat > "${LAUNCHER}" <<EOF
+#!/bin/sh
+set -e
+exec "${SRC_ROOT}/run.sh" "${ARCH}"
+EOF
+chmod +x "${LAUNCHER}"
+ln --symbolic --force "${LAUNCHER}" "${LINK}"
+
 # Copy Icon
+ICON_SRC="${APK_ROOT}/res/drawable/iconx.png"
+if [ ! -f "${ICON_SRC}" ]; then
+    info 'Skipping Desktop Entry'
+    exit 0
+fi
 info 'Copying Icon...'
-ICON="${DATA_ROOT}/icons/hicolor/512x512/apps/${ID}.png"
-cp "${APK_ROOT}/res/drawable/iconx.png" "${ICON}"
+ICON_DST="${DATA_ROOT}/icons/hicolor/512x512/apps/${ID}.png"
+cp "${ICON_SRC}" "${ICON_DST}"
 
 # Generate Desktop Entry
 info 'Creating Desktop Entry...'
@@ -27,9 +45,9 @@ cat > "${APPS}/${ID}.desktop" <<EOF
 [Desktop Entry]
 Name=Ninecraft
 Comment=An MCPE Launcher
-Icon=${ICON}
+Icon=${ICON_DST}
 Path=${APK_ROOT}
-Exec=${SRC_ROOT}/run.sh ${ARCH}
+Exec=${LAUNCHER}
 Type=Application
 Categories=Game;
 Terminal=false

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -9,7 +9,7 @@ NAME='ninecraft'
 # Paths
 DATA_ROOT="${HOME}/.local/share"
 APK_ROOT="$(pwd)"
-SRC_ROOT="$(dirname "$0")"
+SRC_ROOT="$(realpath "$(dirname "$0")")"
 . "${SRC_ROOT}/common.sh"
 
 # Arguments

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -5,19 +5,23 @@ set -e
 # Constants
 ID='io.github.mfdgaming.Ninecraft'
 
-# Arguments
-ARCH="$1"
-
 # Paths
+DATA_ROOT="${HOME}/.local/share"
 APK_ROOT="$(pwd)"
 SRC_ROOT="$(dirname "$0")"
-DATA_ROOT="${HOME}/.local/share"
+. "${SRC_ROOT}/common.sh"
+
+# Arguments
+ARCH="$1"
+validate_arch
 
 # Copy Icon
+info 'Copying Icon...'
 ICON="${DATA_ROOT}/icons/hicolor/512x512/apps/${ID}.png"
 cp "${APK_ROOT}/res/drawable/iconx.png" "${ICON}"
 
 # Generate Desktop Entry
+info 'Creating Desktop Entry...'
 APPS="${DATA_ROOT}/applications"
 cat > "${APPS}/${ID}.desktop" <<EOF
 [Desktop Entry]

--- a/docker/prepare.sh
+++ b/docker/prepare.sh
@@ -46,6 +46,5 @@ docker build \
     --build-arg "$(get CONTAINER_PREFIX)" \
     --build-arg "USER_ID=$(id -u)" \
     --build-arg "GROUP_ID=$(id -g)" \
-    --build-arg "RENDER_GROUP_ID=$(gid render)" \
-    --build-arg "VIDEO_GROUP_ID=$(gid video)" \
+    --build-arg "EXTRA_GROUP_IDS=$(gid render) $(gid video) $(gid audio)" \
     .

--- a/docker/prepare.sh
+++ b/docker/prepare.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
 
 set -e
+
+# Prepare
 cd "$(dirname "$0")"
+. ./common.sh
 
 # Constants
 export VERSION='trixie'
@@ -9,34 +12,21 @@ export VERSION='trixie'
 # Arguments
 TYPE="$1"
 ARCH="$2"
-
-# Select Architecture
-case "${ARCH}" in
-    i686)
-        PLATFORM='linux/386'
-        CONTAINER_PREFIX='i386/'
-        ;;
-    arm)
-        PLATFORM='linux/arm/v7'
-        CONTAINER_PREFIX='arm32v7/'
-        ;;
-    *)
-        echo "Unsupported Architecture: ${ARCH}"
-        exit 1
-        ;;
-esac
+validate_arch
 export CONTAINER_PREFIX
 
-# Functions
+# Get Group ID
 gid() {
     NAME="$1"
     getent group "${NAME}" | cut -d: -f3
 }
 
 # Build
+TAG="ninecraft-${TYPE}-${ARCH}"
+info "Building Docker Image: ${TAG}..."
 cd "${TYPE}"
 docker build \
-    --tag "ninecraft-${TYPE}-${ARCH}" \
+    --tag "${TAG}" \
     --platform "${PLATFORM}" \
     --build-arg VERSION \
     --build-arg CONTAINER_PREFIX \

--- a/docker/prepare.sh
+++ b/docker/prepare.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+set -e
+cd "$(dirname "$0")"
+
+# Constants
+VERSION='trixie'
+
+# Arguments
+TYPE="$1"
+ARCH="$2"
+
+# Select Architecture
+case "${ARCH}" in
+    i686)
+        PLATFORM='linux/386'
+        CONTAINER_PREFIX='i386/'
+        ;;
+    arm)
+        PLATFORM='linux/arm/v7'
+        CONTAINER_PREFIX='arm32v7/'
+        ;;
+    *)
+        echo "Unsupported Architecture: ${ARCH}"
+        exit 1
+        ;;
+esac
+
+# Functions
+get() {
+    VAR="$1"
+    eval "VALUE=\${${VAR}}"
+    echo "${VAR}=${VALUE}"
+}
+gid() {
+    NAME="$1"
+    getent group "${NAME}" | cut -d: -f3
+}
+
+# Build
+cd "${TYPE}"
+docker build \
+    --tag "ninecraft-${TYPE}-${ARCH}" \
+    --platform "${PLATFORM}" \
+    --build-arg "$(get VERSION)" \
+    --build-arg "$(get CONTAINER_PREFIX)" \
+    --build-arg "USER_ID=$(id -u)" \
+    --build-arg "GROUP_ID=$(id -g)" \
+    --build-arg "RENDER_GROUP_ID=$(gid render)" \
+    --build-arg "VIDEO_GROUP_ID=$(gid video)" \
+    .

--- a/docker/prepare.sh
+++ b/docker/prepare.sh
@@ -4,7 +4,7 @@ set -e
 cd "$(dirname "$0")"
 
 # Constants
-VERSION='trixie'
+export VERSION='trixie'
 
 # Arguments
 TYPE="$1"
@@ -25,13 +25,9 @@ case "${ARCH}" in
         exit 1
         ;;
 esac
+export CONTAINER_PREFIX
 
 # Functions
-get() {
-    VAR="$1"
-    eval "VALUE=\${${VAR}}"
-    echo "${VAR}=${VALUE}"
-}
 gid() {
     NAME="$1"
     getent group "${NAME}" | cut -d: -f3
@@ -42,9 +38,9 @@ cd "${TYPE}"
 docker build \
     --tag "ninecraft-${TYPE}-${ARCH}" \
     --platform "${PLATFORM}" \
-    --build-arg "$(get VERSION)" \
-    --build-arg "$(get CONTAINER_PREFIX)" \
+    --build-arg VERSION \
+    --build-arg CONTAINER_PREFIX \
     --build-arg "USER_ID=$(id -u)" \
     --build-arg "GROUP_ID=$(id -g)" \
-    --build-arg "EXTRA_GROUP_IDS=$(gid render) $(gid video) $(gid audio)" \
+    --build-arg "EXTRA_GROUP_IDS=$(gid render) $(gid video) $(gid input)" \
     .

--- a/docker/prepare.sh
+++ b/docker/prepare.sh
@@ -28,6 +28,7 @@ cd "${TYPE}"
 docker build \
     --tag "${TAG}" \
     --platform "${PLATFORM}" \
+    --network host \
     --build-arg VERSION \
     --build-arg CONTAINER_PREFIX \
     --build-arg "USER_ID=$(id -u)" \

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -66,12 +66,16 @@ fi
 
 # Vibration
 for DEVICE in /sys/class/input/event*; do
-    if [ -e "${DEVICE}" ] && [ -f "${DEVICE}/device/force_feedback/ff_effects_max" ]; then
-        NAME="$(basename "${DEVICE}")"
-        info "Adding Force-Feedback Device: ${NAME}"
-        set -- "$@" \
-            --device "/dev/${NAME}"
-    fi
+    # Check Capabilities
+    FF_CAPABILITIES_FILE="${DEVICE}/device/capabilities/ff"
+    [ -r "${FF_CAPABILITIES_FILE}" ] || continue
+    read -r FF_CAPABILITIES < "${FF_CAPABILITIES_FILE}"
+    [ "${FF_CAPABILITIES}" != '0' ] || continue
+    # Add Device
+    NAME="$(basename "${DEVICE}")"
+    info "Adding Force-Feedback Device: ${NAME}"
+    set -- "$@" \
+        --device "/dev/input/${NAME}"
 done
 
 # Audio

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+set -e
+
+# Arguments
+ARCH="$1"
+
+# Run
+get() {
+    VAR="$1"
+    eval "VALUE=\${${VAR}}"
+    echo "${VAR}=${VALUE}"
+}
+exec docker run \
+    --rm \
+    --privileged \
+    --tty \
+    --hostname "$(hostname)" \
+    --volume "$(pwd):/data" \
+    --workdir '/data' \
+    --env "$(get GALLIUM_HUD)" \
+    --env "SDL_VIDEODRIVER=wayland,x11" \
+    --volume '/tmp/.X11-unix:/tmp/.X11-unix' \
+    --env "$(get DISPLAY)" \
+    --volume "${XAUTHORITY}:${XAUTHORITY}" \
+    --env "$(get XAUTHORITY)" \
+    --volume "${XDG_RUNTIME_DIR}:${XDG_RUNTIME_DIR}" \
+    --env "$(get XDG_RUNTIME_DIR)" \
+    --env "$(get WAYLAND_DISPLAY)" \
+    "ninecraft-run-${ARCH}"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -3,25 +3,12 @@
 set -e
 
 # Utility Functions
-error() {
-    echo "ERROR:" "$@"
-    exit 1
-}
-info() {
-    echo "INFO:" "$@"
-}
-require_file() {
-    FILE="$1"
-    if [ ! -e "${FILE}" ]; then
-        error "Missing File: ${FILE}"
-    fi
-}
+. "$(dirname "$0")/common.sh"
 
 # Arguments
 ARCH="$1"
-if [ -z "${ARCH}" ]; then
-    error 'Missing Architecture'
-fi
+validate_arch
+require_file "lib/${ANDROID_ARCH}/libminecraftpe.so"
 
 # Basic Arguments
 set -- docker run \
@@ -44,13 +31,14 @@ set -- "$@" \
     --publish "$(pass_port 19132 udp)" \
     --publish "$(pass_port 4711 tcp)"
 
-# HUD (https://docs.mesa3d.org/envvars.html#gallium-environment-variables)
+# HUD
+# See: https://docs.mesa3d.org/envvars.html#gallium-environment-variables
 set -- "$@" \
     --env GALLIUM_HUD
 
 # Wayland/X11
 using() {
-    info "Using" "$@"
+    info 'Using' "$@"
 }
 pass_volume() {
     VAR="$1"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -5,26 +5,76 @@ set -e
 # Arguments
 ARCH="$1"
 
-# Run
-get() {
+# Utility Functions
+pass_env() {
     VAR="$1"
     eval "VALUE=\${${VAR}}"
     echo "${VAR}=${VALUE}"
 }
-exec docker run \
+pass_volume() {
+    VAR="$1"
+    eval "VALUE=\${${VAR}}"
+    echo "${VALUE}:${VALUE}"
+}
+
+# Basic Arguments
+set -- docker run \
     --rm \
-    --privileged \
-    --tty \
-    --hostname "$(hostname)" \
-    --volume "$(pwd):/data" \
-    --workdir '/data' \
-    --env "$(get GALLIUM_HUD)" \
-    --env "SDL_VIDEODRIVER=wayland,x11" \
-    --volume '/tmp/.X11-unix:/tmp/.X11-unix' \
-    --env "$(get DISPLAY)" \
-    --volume "${XAUTHORITY}:${XAUTHORITY}" \
-    --env "$(get XAUTHORITY)" \
-    --volume "${XDG_RUNTIME_DIR}:${XDG_RUNTIME_DIR}" \
-    --env "$(get XDG_RUNTIME_DIR)" \
-    --env "$(get WAYLAND_DISPLAY)" \
+    --tty
+
+# Access Current Directory
+DATA_ROOT='/data'
+set -- "$@" \
+    --volume "$(pwd):${DATA_ROOT}" \
+    --workdir "${DATA_ROOT}"
+
+# HUD
+# https://docs.mesa3d.org/envvars.html#gallium-environment-variables
+set -- "$@" \
+    --env "$(pass_env GALLIUM_HUD)"
+
+# Wayland/X11
+if [ "${XDG_SESSION_TYPE}" = 'wayland' ]; then
+    set -- "$@" \
+        --env 'SDL_VIDEODRIVER=wayland' \
+        --volume "$(pass_volume XDG_RUNTIME_DIR)" \
+        --env "$(pass_env XDG_RUNTIME_DIR)" \
+        --env "$(pass_env WAYLAND_DISPLAY)"
+else
+    X11_SOCKET='/tmp/.X11-unix'
+    set -- "$@" \
+        --env "SDL_VIDEODRIVER=x11" \
+        --volume "$(pass_volume X11_SOCKET)" \
+        --env "$(pass_env DISPLAY)" \
+        --volume "$(pass_volume XAUTHORITY)" \
+        --env "$(pass_env XAUTHORITY)" \
+        --hostname "$(hostname)"
+fi
+
+# Audio
+PULSE_SOCKET="${XDG_RUNTIME_DIR}/pulse/native"
+PULSE_COOKIE="${HOME}/.config/pulse/cookie"
+set -- "$@" \
+    --env 'SDL_AUDIODRIVER=pulseaudio' \
+    --volume "$(pass_volume PULSE_SOCKET)" \
+    --volume "$(pass_volume PULSE_COOKIE)" \
+    --env "PULSE_SERVER=unix:${PULSE_SOCKET}"
+
+# OpenGL Acceleration
+VIRGL='/tmp/.virgl_test'
+if fuser "${VIRGL}" > /dev/null 2>&1; then
+    set -- "$@" \
+        --volume "$(pass_volume VIRGL)" \
+        --env 'LIBGL_ALWAYS_SOFTWARE=1' \
+        --env 'GALLIUM_DRIVER=virpipe'
+else
+    set -- "$@" \
+        --device /dev/dri
+fi
+
+# Docker Image
+set -- "$@" \
     "ninecraft-run-${ARCH}"
+
+# Run
+exec "$@"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -22,14 +22,8 @@ set -- "$@" \
     --workdir "${DATA_ROOT}"
 
 # Networking
-pass_port() {
-    PORT="$1"
-    TYPE="$2"
-    echo "${PORT}:${PORT}/${TYPE}"
-}
 set -- "$@" \
-    --publish "$(pass_port 19132 udp)" \
-    --publish "$(pass_port 4711 tcp)"
+    --network host
 
 # HUD
 # See: https://docs.mesa3d.org/envvars.html#gallium-environment-variables

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -2,20 +2,26 @@
 
 set -e
 
+# Utility Functions
+error() {
+    echo "ERROR:" "$@"
+    exit 1
+}
+info() {
+    echo "INFO:" "$@"
+}
+require_file() {
+    FILE="$1"
+    if [ ! -e "${FILE}" ]; then
+        error "Missing File: ${FILE}"
+    fi
+}
+
 # Arguments
 ARCH="$1"
-
-# Utility Functions
-pass_env() {
-    VAR="$1"
-    eval "VALUE=\${${VAR}}"
-    echo "${VAR}=${VALUE}"
-}
-pass_volume() {
-    VAR="$1"
-    eval "VALUE=\${${VAR}}"
-    echo "${VALUE}:${VALUE}"
-}
+if [ -z "${ARCH}" ]; then
+    error 'Missing Architecture'
+fi
 
 # Basic Arguments
 set -- docker run \
@@ -28,46 +34,90 @@ set -- "$@" \
     --volume "$(pwd):${DATA_ROOT}" \
     --workdir "${DATA_ROOT}"
 
-# HUD
-# https://docs.mesa3d.org/envvars.html#gallium-environment-variables
+# Networking
+pass_port() {
+    PORT="$1"
+    TYPE="$2"
+    echo "${PORT}:${PORT}/${TYPE}"
+}
 set -- "$@" \
-    --env "$(pass_env GALLIUM_HUD)"
+    --publish "$(pass_port 19132 udp)" \
+    --publish "$(pass_port 4711 tcp)"
+
+# HUD (https://docs.mesa3d.org/envvars.html#gallium-environment-variables)
+set -- "$@" \
+    --env GALLIUM_HUD
 
 # Wayland/X11
+using() {
+    info "Using" "$@"
+}
+pass_volume() {
+    VAR="$1"
+    eval "VALUE=\${${VAR}}"
+    echo "${VALUE}:${VALUE}"
+}
 if [ "${XDG_SESSION_TYPE}" = 'wayland' ]; then
+    using Wayland
+    require_file "${XDG_RUNTIME_DIR}"
     set -- "$@" \
         --env 'SDL_VIDEODRIVER=wayland' \
-        --volume "$(pass_volume XDG_RUNTIME_DIR)" \
-        --env "$(pass_env XDG_RUNTIME_DIR)" \
-        --env "$(pass_env WAYLAND_DISPLAY)"
+        --env WAYLAND_DISPLAY \
+        --env XDG_RUNTIME_DIR \
+        --volume "$(pass_volume XDG_RUNTIME_DIR)"
 else
+    using X11
     X11_SOCKET='/tmp/.X11-unix'
+    require_file "${X11_SOCKET}"
     set -- "$@" \
         --env "SDL_VIDEODRIVER=x11" \
         --volume "$(pass_volume X11_SOCKET)" \
-        --env "$(pass_env DISPLAY)" \
-        --volume "$(pass_volume XAUTHORITY)" \
-        --env "$(pass_env XAUTHORITY)" \
+        --env DISPLAY \
         --hostname "$(hostname)"
+    if [ -n "${XAUTHORITY}" ]; then
+        require_file "${XAUTHORITY}"
+        set -- "$@" \
+            --env XAUTHORITY \
+            --volume "$(pass_volume XAUTHORITY)"
+    fi
 fi
+
+# Vibration
+for DEVICE in /sys/class/input/event*; do
+    if [ -e "${DEVICE}" ] && [ -f "${DEVICE}/device/force_feedback/ff_effects_max" ]; then
+        NAME="$(basename "${DEVICE}")"
+        info "Adding Force-Feedback Device: ${NAME}"
+        set -- "$@" \
+            --device "/dev/${NAME}"
+    fi
+done
 
 # Audio
 PULSE_SOCKET="${XDG_RUNTIME_DIR}/pulse/native"
-PULSE_COOKIE="${HOME}/.config/pulse/cookie"
-set -- "$@" \
-    --env 'SDL_AUDIODRIVER=pulseaudio' \
-    --volume "$(pass_volume PULSE_SOCKET)" \
-    --volume "$(pass_volume PULSE_COOKIE)" \
-    --env "PULSE_SERVER=unix:${PULSE_SOCKET}"
+if [ -S "${PULSE_SOCKET}" ]; then
+    using PulseAudio
+    PULSE_COOKIE="${HOME}/.config/pulse/cookie"
+    require_file "${PULSE_COOKIE}"
+    set -- "$@" \
+        --env 'SDL_AUDIODRIVER=pulseaudio' \
+        --volume "$(pass_volume PULSE_SOCKET)" \
+        --volume "$(pass_volume PULSE_COOKIE)" \
+        --env "PULSE_SERVER=unix:${PULSE_SOCKET}"
+else
+    set -- "$@" \
+        --env 'SDL_AUDIODRIVER=dummy'
+fi
 
 # OpenGL Acceleration
 VIRGL='/tmp/.virgl_test'
-if fuser "${VIRGL}" > /dev/null 2>&1; then
+if [ -S "${VIRGL}" ] && fuser "${VIRGL}" > /dev/null 2>&1; then
+    using VirGL
     set -- "$@" \
         --volume "$(pass_volume VIRGL)" \
         --env 'LIBGL_ALWAYS_SOFTWARE=1' \
         --env 'GALLIUM_DRIVER=virpipe'
 else
+    using OpenGL
     set -- "$@" \
         --device /dev/dri
 fi
@@ -77,4 +127,5 @@ set -- "$@" \
     "ninecraft-run-${ARCH}"
 
 # Run
+info 'Running:' "$@"
 exec "$@"

--- a/docker/run/Dockerfile
+++ b/docker/run/Dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1
+# check=error=true;skip=InvalidDefaultArgInFrom
+
+# Base Container
+ARG CONTAINER_PREFIX
+ARG VERSION
+FROM "${CONTAINER_PREFIX}debian:${VERSION}"
+
+# Install Dependencies
+RUN \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        zlib1g \
+        libsdl2-2.0-0 \
+        libglvnd0 \
+        libgl1 libgl1-mesa-dri \
+        libegl1 libegl-mesa0 \
+        libglx-mesa0 \
+        libdecor-0-0 libdecor-0-plugin-1-cairo \
+        zenity && \
+    rm -rf /var/lib/apt/lists/*
+
+# Setup User
+ARG USER_ID
+ARG GROUP_ID
+ARG RENDER_GROUP_ID
+ARG VIDEO_GROUP_ID
+RUN \
+    groupadd --non-unique --gid "${GROUP_ID}" main && \
+    groupadd --non-unique --gid "${RENDER_GROUP_ID}" one && \
+    groupadd --non-unique --gid "${VIDEO_GROUP_ID}" two && \
+    useradd --non-unique --create-home --uid "${USER_ID}" --gid "${GROUP_ID}" --groups one,two user
+USER user
+
+# Add App
+COPY ninecraft /
+ENTRYPOINT ["/ninecraft"]

--- a/docker/run/Dockerfile
+++ b/docker/run/Dockerfile
@@ -4,7 +4,7 @@
 # Base Container
 ARG CONTAINER_PREFIX
 ARG VERSION
-FROM "${CONTAINER_PREFIX}debian:${VERSION}"
+FROM ${CONTAINER_PREFIX}debian:${VERSION}
 
 # Install Dependencies
 RUN \

--- a/docker/run/Dockerfile
+++ b/docker/run/Dockerfile
@@ -23,13 +23,14 @@ RUN \
 # Setup User
 ARG USER_ID
 ARG GROUP_ID
-ARG RENDER_GROUP_ID
-ARG VIDEO_GROUP_ID
+ARG EXTRA_GROUP_IDS
 RUN \
     groupadd --non-unique --gid "${GROUP_ID}" main && \
-    groupadd --non-unique --gid "${RENDER_GROUP_ID}" one && \
-    groupadd --non-unique --gid "${VIDEO_GROUP_ID}" two && \
-    useradd --non-unique --create-home --uid "${USER_ID}" --gid "${GROUP_ID}" --groups one,two user
+    useradd --non-unique --create-home --uid "${USER_ID}" --gid "${GROUP_ID}" user && \
+    for group in ${EXTRA_GROUP_IDS:-}; do \
+        groupadd --non-unique --gid "${group}" "group_${group}" && \
+        usermod --append --groups "group_${group}" user; \
+    done
 USER user
 
 # Add App

--- a/ninecraft/include/ninecraft/ptpatch/apply.h
+++ b/ninecraft/include/ninecraft/ptpatch/apply.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int apply_ptpatches(const char *src, const char *dst, const char *patches_dir);

--- a/ninecraft/include/ninecraft/ptpatch/lib.h
+++ b/ninecraft/include/ninecraft/ptpatch/lib.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <sys/types.h>
+
+typedef struct {
+    int version_code;
+    int patch_count;
+} patch_data_t;
+typedef enum {
+    PATCH_OK,
+    PATCH_SKIPPED,
+    PATCH_INVALID
+} patch_ret_t;
+
+typedef int (*patch_data_callback_t)(patch_data_t *data, void *user_data);
+typedef void (*patch_apply_callback_t)(off_t offset, size_t data_length, unsigned char *data, void *user_data);
+patch_ret_t load_patch(const char *path, patch_data_callback_t on_data, patch_apply_callback_t on_apply, void *user_data);

--- a/ninecraft/src/AppPlatform_linux.c
+++ b/ninecraft/src/AppPlatform_linux.c
@@ -29,6 +29,7 @@ ninecraft_options_t platform_options = {
     .capasity = 0
 };
 bool is_keyboard_visible = false;
+extern SDL_Haptic *_haptic;
 
 void *app_platform_vtable_0_1_0[] = {
     (void *)AppPlatform_linux$saveScreenshot,
@@ -1211,14 +1212,9 @@ void AppPlatform_linux$vibrate(AppPlatform_linux *app_platform, int milliseconds
         milliseconds = min_milliseconds;
     }
     // Play Vibration
-    SDL_Haptic *haptic = SDL_HapticOpen(0);
-    if (haptic == NULL) {
-        return;
+    if (_haptic && SDL_HapticRumbleInit(_haptic) == 0) {
+        SDL_HapticRumblePlay(_haptic, 1, milliseconds);
     }
-    if (SDL_HapticRumbleInit(haptic) == 0) {
-        SDL_HapticRumblePlay(haptic, 1, milliseconds);
-    }
-    SDL_HapticClose(haptic);
 }
 
 void AppPlatform_linux$destroy(AppPlatform_linux *app_platform) {

--- a/ninecraft/src/AppPlatform_linux.c
+++ b/ninecraft/src/AppPlatform_linux.c
@@ -1205,15 +1205,18 @@ void AppPlatform_linux$uploadPlatformDependentData(AppPlatform_linux *app_platfo
 
 void AppPlatform_linux$vibrate(AppPlatform_linux *app_platform, int milliseconds) {
     //puts("debug: AppPlatform_linux::vibrate");
+    // Some Vibration Motors Ignore Short Vibrations
+    static int min_milliseconds = 150;
+    if (milliseconds < min_milliseconds) {
+        milliseconds = min_milliseconds;
+    }
+    // Play Vibration
     SDL_Haptic *haptic = SDL_HapticOpen(0);
     if (haptic == NULL) {
         return;
     }
-    if (SDL_HapticRumbleInit(haptic) != 0) {
-        return;
-    }
-    if (SDL_HapticRumblePlay(haptic, 1, milliseconds) != 0) {
-        return;
+    if (SDL_HapticRumbleInit(haptic) == 0) {
+        SDL_HapticRumblePlay(haptic, 1, milliseconds);
     }
     SDL_HapticClose(haptic);
 }

--- a/ninecraft/src/AppPlatform_linux.c
+++ b/ninecraft/src/AppPlatform_linux.c
@@ -674,7 +674,7 @@ bool AppPlatform_linux$supportsTouchscreen(AppPlatform_linux *app_platform) {
 
 bool AppPlatform_linux$supportsVibration(AppPlatform_linux *app_platform) {
     //puts("debug: AppPlatform_linux::supportsVibration");
-    return false;
+    return true;
 }
 
 void AppPlatform_linux$getSessionIDAndRefreshToken(AppPlatform_linux *app_platform, android_string_t *session_id, android_string_t *refresh_token) {
@@ -1196,6 +1196,17 @@ void AppPlatform_linux$uploadPlatformDependentData(AppPlatform_linux *app_platfo
 
 void AppPlatform_linux$vibrate(AppPlatform_linux *app_platform, int milliseconds) {
     //puts("debug: AppPlatform_linux::vibrate");
+    SDL_Haptic *haptic = SDL_HapticOpen(0);
+    if (haptic == NULL) {
+        return;
+    }
+    if (SDL_HapticRumbleInit(haptic) != 0) {
+        return;
+    }
+    if (SDL_HapticRumblePlay(haptic, 1, milliseconds) != 0) {
+        return;
+    }
+    SDL_HapticClose(haptic);
 }
 
 void AppPlatform_linux$destroy(AppPlatform_linux *app_platform) {

--- a/ninecraft/src/AppPlatform_linux.c
+++ b/ninecraft/src/AppPlatform_linux.c
@@ -1006,6 +1006,9 @@ bool AppPlatform_linux$hasBuyButtonWhenInvalidLicense(AppPlatform_linux *app_pla
 
 void AppPlatform_linux$hideKeyboard(AppPlatform_linux *app_platform) {
     //puts("debug: AppPlatform_linux::hideKeyboard");
+    if (is_keyboard_visible) {
+        SDL_StopTextInput();
+    }
     is_keyboard_visible = false;
 }
 
@@ -1182,11 +1185,17 @@ void AppPlatform_linux$showDialog(AppPlatform_linux *app_platform, int dialog_id
 
 void AppPlatform_linux$showKeyboard(AppPlatform_linux *app_platform) {
     //puts("debug: AppPlatform_linux::showKeyboard");
+    if (!is_keyboard_visible) {
+        SDL_StartTextInput();
+    }
     is_keyboard_visible = true;
 }
 
 void AppPlatform_linux$showKeyboard2(AppPlatform_linux *app_platform, bool show) {
     //puts("debug: AppPlatform_linux::showKeyboard2");
+    if (!is_keyboard_visible) {
+        SDL_StartTextInput();
+    }
     is_keyboard_visible = true;
 }
 

--- a/ninecraft/src/main.c
+++ b/ninecraft/src/main.c
@@ -244,6 +244,7 @@ static void touch_feed(struct SDL_Window *window, char button, char type, float 
     ypos *= height;
     xrel *= width;
     yrel *= height;
+    // TODO Support 0.12
     if (version_id == version_id_0_1_0) {
         ((void (*)(int, int, int, int))android_dlsym(handle, "_ZN5Mouse4feedEiiii"))(button, type, (int)xpos, (int)ypos);
     } else if (version_id >= version_id_0_6_0 && version_id < version_id_0_12_1) {
@@ -749,7 +750,7 @@ float calculate_scale(int width, int height, float dpi) {
 }
 
 static void set_ninecraft_size(int width, int height) {
-    glClear(GL_DEPTH_BUFFER_BIT);
+    glClear(GL_DEPTH_BUFFER_BIT); // Needed To Fix v0.8.1 On Some Systems
     float ddpi = 96.0f;
     SDL_GetDisplayDPI(SDL_GetWindowDisplayIndex(_window), &ddpi, NULL, NULL);
     float scale = calculate_scale(width, height, ddpi);    

--- a/ninecraft/src/main.c
+++ b/ninecraft/src/main.c
@@ -56,6 +56,7 @@
 
 void *handle = NULL;
 struct SDL_Window *_window = NULL;
+SDL_Haptic *_haptic = NULL;
 bool ctrl_pressed = false;
 bool is_fullscreen = false;
 
@@ -1776,7 +1777,6 @@ int main(int argc, char **argv) {
         return 1;
     }
     SDL_StopTextInput();
-    SDL_Init(SDL_INIT_HAPTIC);
 
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
@@ -1866,6 +1866,10 @@ int main(int argc, char **argv) {
 
     if (!handle) {
         puts("libminecraftpe.so not loaded");
+        audio_engine_destroy();
+        SDL_GL_DeleteContext(gl_context);
+        SDL_DestroyWindow(_window);
+        SDL_Quit();
         free(storage_path);
         free(mods_path);
         free(global_overrides_path);
@@ -1877,12 +1881,20 @@ int main(int argc, char **argv) {
     android_alloc_setup_hooks(handle);
 
     if (!detect_version()) {
+        audio_engine_destroy();
+        SDL_GL_DeleteContext(gl_context);
+        SDL_DestroyWindow(_window);
+        SDL_Quit();
         free(storage_path);
         free(mods_path);
         free(global_overrides_path);
         free(ovc_path);
         free(icon_path);
         return 1;
+    }
+
+    if (SDL_Init(SDL_INIT_HAPTIC) >= 0) {
+        _haptic = SDL_HapticOpen(0);
     }
 
     multitouch_setup_hooks(handle);
@@ -2397,6 +2409,9 @@ int main(int argc, char **argv) {
                 }
             }
         }
+    }
+    if (_haptic) {
+        SDL_HapticClose(_haptic);
     }
     audio_engine_destroy();
     SDL_GL_DeleteContext(gl_context);

--- a/ninecraft/src/main.c
+++ b/ninecraft/src/main.c
@@ -1181,7 +1181,7 @@ static void key_callback(struct SDL_Window *window, int key, int scancode, int a
                         }
                     }
                 }
-            } else if (version_id >= version_id_0_1_1 && key == SDLK_ESCAPE) {
+            } else if (version_id >= version_id_0_1_1 && (key == SDLK_ESCAPE || key == SDLK_AC_BACK)) {
                 if (action == SDL_KEYDOWN) {
                     if (version_id >= version_id_0_10_0) {
 #ifdef _WIN32

--- a/ninecraft/src/main.c
+++ b/ninecraft/src/main.c
@@ -29,6 +29,7 @@
 #include <ninecraft/mods/inject.h>
 #include <ninecraft/mods/mod_loader.h>
 #include <ninecraft/app_platform.h>
+#include <ninecraft/ptpatch/apply.h>
 #include <math.h>
 #include <wchar.h>
 #include <wctype.h>
@@ -69,7 +70,7 @@ static float *controller_y_stick;
 
 bool mouse_pointer_hidden = false;
 
-void *load_library(const char *name, bool show_error) {
+void *load_library(const char *name, bool show_error, bool apply_ptpatch) {
 #if defined(__i386__) || defined(_M_IX86)
     char *arch = "x86";
 #else
@@ -87,7 +88,24 @@ void *load_library(const char *name, bool show_error) {
     strcat(fullpath, "/");
     strcat(fullpath, name);
 
-    void *handle = android_dlopen(fullpath, ANDROID_RTLD_LAZY);
+    void *handle;
+    if (apply_ptpatch) {
+        char *patches_path = (char *)malloc(1024);
+        patches_path[0] = '\0';
+        strcat(patches_path, game_parameters.home_path);
+        strcat(patches_path, "/patches");
+        char *patched_file_path = (char *)malloc(1024);
+        strcat(patched_file_path, patches_path);
+        strcat(patched_file_path, "/");
+        strcat(patched_file_path, name);
+        const int ret = apply_ptpatches(fullpath, patched_file_path, patches_path);
+        handle = android_dlopen(ret ? patched_file_path : fullpath, ANDROID_RTLD_LAZY);
+        unlink(patched_file_path);
+        free(patched_file_path);
+        free(patches_path);
+    } else {
+        handle = android_dlopen(fullpath, ANDROID_RTLD_LAZY);
+    }
     if (handle == NULL) {
         const char *e = android_dlerror();
         if (show_error) {
@@ -1835,15 +1853,15 @@ int main(int argc, char **argv) {
     so_libopensles = android_library_create("libOpenSLES.so");
     so_libz = android_library_create("libz.so");
 
-    so_libgnustl_shared = load_library("libgnustl_shared.so", false);
-    so_libfmod = load_library("libfmod.so", false);
+    so_libgnustl_shared = load_library("libgnustl_shared.so", false, false);
+    so_libfmod = load_library("libfmod.so", false, false);
 
     if (so_libfmod) {
         fmod_anjni();
         ((void (*)(JavaVM *, void *))android_dlsym(so_libfmod, "JNI_OnLoad"))(android_JavaVM, NULL);
     }
 
-    handle = load_library("libminecraftpe.so", true);
+    handle = load_library("libminecraftpe.so", true, true);
 
     if (!handle) {
         puts("libminecraftpe.so not loaded");

--- a/ninecraft/src/main.c
+++ b/ninecraft/src/main.c
@@ -1775,6 +1775,7 @@ int main(int argc, char **argv) {
         free(icon_path);
         return 1;
     }
+    SDL_StopTextInput();
     SDL_Init(SDL_INIT_HAPTIC);
 
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);

--- a/ninecraft/src/main.c
+++ b/ninecraft/src/main.c
@@ -1756,6 +1756,7 @@ int main(int argc, char **argv) {
         free(icon_path);
         return 1;
     }
+    SDL_Init(SDL_INIT_HAPTIC);
 
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);

--- a/ninecraft/src/main.c
+++ b/ninecraft/src/main.c
@@ -138,7 +138,27 @@ int mouseToGameKeyCode(int keyCode) {
     return 0;
 }
 
+static void convert_window_xy_to_framebuffer_xy(struct SDL_Window *window, int *x, int *y) {
+    if (SDL_GetRelativeMouseMode() == SDL_TRUE) {
+        return;
+    }
+    int window_width = 0;
+    int window_height = 0;
+    SDL_GetWindowSize(window, &window_width, &window_height);
+    if (window_width <= 0 || window_height <= 0) {
+        return;
+    }
+    int framebuffer_width = 0;
+    int framebuffer_height = 0;
+    SDL_GL_GetDrawableSize(window, &framebuffer_width, &framebuffer_height);
+    float scale_x = ((float) framebuffer_width) / ((float) window_width);
+    float scale_y = ((float) framebuffer_height) / ((float) window_height);
+    *x *= scale_x;
+    *y *= scale_y;
+}
+
 static void mouse_click_callback(struct SDL_Window *window, int button, int action, int x, int y) {
+    convert_window_xy_to_framebuffer_xy(window, &x, &y);
     int mc_button = (button == SDL_BUTTON_LEFT ? 1 : (button == SDL_BUTTON_RIGHT ? 2 : 0));
     if (!mc_button) {
         return;
@@ -186,6 +206,8 @@ static void mouse_scroll_callback(struct SDL_Window *window, float xoffset, floa
 }
 
 static void mouse_pos_callback(struct SDL_Window *window, int xpos, int ypos, int xrel, int yrel) {
+    convert_window_xy_to_framebuffer_xy(window, &xpos, &ypos);
+    convert_window_xy_to_framebuffer_xy(window, &xrel, &yrel);
     if (version_id >= version_id_0_12_1) {
         if (mouse_pointer_hidden) {
             mouse_device_feed_0_12(android_dlsym(handle, "_ZN5Mouse9_instanceE"), 0, 0, (short)xpos, (short)ypos, (short)xrel, (short)yrel);
@@ -210,6 +232,82 @@ static void mouse_pos_callback(struct SDL_Window *window, int xpos, int ypos, in
             controller_states[1] = 1;
             controller_x_stick[1] += (float)xrel * 0.003;
             controller_y_stick[1] -= (float)yrel * 0.003;
+        }
+    }
+}
+
+static void touch_feed(struct SDL_Window *window, char button, char type, float xpos, float ypos, float xrel, float yrel, char pointer_id) {
+    int width = 0;
+    int height = 0;
+    SDL_GL_GetDrawableSize(window, &width, &height);
+    xpos *= width;
+    ypos *= height;
+    xrel *= width;
+    yrel *= height;
+    if (version_id == version_id_0_1_0) {
+        ((void (*)(int, int, int, int))android_dlsym(handle, "_ZN5Mouse4feedEiiii"))(button, type, (int)xpos, (int)ypos);
+    } else if (version_id >= version_id_0_6_0 && version_id < version_id_0_12_1) {
+        mouse_device_feed_0_6(android_dlsym(handle, "_ZN5Mouse9_instanceE"), button, type, (short)xpos, (short)ypos, (short)xrel, (short)yrel);
+        multitouch_feed_0_6(button, type, (short)xpos, (short)ypos, pointer_id);
+    } else if (version_id <= version_id_0_5_0_j && version_id >= version_id_0_2_1) {
+        mouse_device_feed_0_2_1(android_dlsym(handle, "_ZN5Mouse9_instanceE"), button, type, (short)xpos, (short)ypos);
+        multitouch_feed_0_2_1(button, type, (short)xpos, (short)ypos, pointer_id);
+    } else if (version_id <= version_id_0_2_0_j && version_id >= version_id_0_1_0_touch) {
+        mouse_device_feed_0_1(android_dlsym(handle, "_ZN5Mouse9_instanceE"), button, type, (short)xpos, (short)ypos);
+        multitouch_feed_0_1(button, type, (short)xpos, (short)ypos, pointer_id);
+    }
+}
+#define MAX_TOUCHES (8)
+struct touch_id_data {
+    int active;
+    SDL_TouchID device;
+    SDL_FingerID finger;
+};
+static struct touch_id_data touch_ids[MAX_TOUCHES];
+static char touch_get_id(SDL_TouchID device, SDL_FingerID finger) {
+    // ID 0 Is Reserved For The Mouse
+    int start = 1;
+    // Search For Active ID
+    for (int i = start; i < MAX_TOUCHES; i++) {
+        struct touch_id_data *data = touch_ids + i;
+        if (data->active && data->device == device && data->finger == finger) {
+            return i;
+        }
+    }
+    // Not Found
+    for (int i = start; i < MAX_TOUCHES; i++) {
+        // Find First Inactive ID, And Activate It
+        struct touch_id_data *data = touch_ids + i;
+        if (!data->active) {
+            data->active = 1;
+            data->device = device;
+            data->finger = finger;
+            return i;
+        }
+    }
+    // Fail
+    return 0;
+}
+static void touch_drop_id(int id) {
+    touch_ids[id].active = 0;
+}
+static void touch_callback(struct SDL_Window *window, float xpos, float ypos, float xrel, float yrel, int type, char id) {
+    if (id == 0) {
+        return;
+    }
+    switch (type) {
+        case SDL_FINGERDOWN:
+        case SDL_FINGERUP: {
+            char data = type == SDL_FINGERUP ? 0 : 1;
+            touch_feed(window, 1, data, xpos, ypos, xrel, yrel, id);
+            if (type == SDL_FINGERUP) {
+                touch_drop_id(id);
+            }
+            break;
+        }
+        case SDL_FINGERMOTION: {
+            touch_feed(window, 0, 0, xpos, ypos, xrel, yrel, id);
+            break;
         }
     }
 }
@@ -651,6 +749,7 @@ float calculate_scale(int width, int height, float dpi) {
 }
 
 static void set_ninecraft_size(int width, int height) {
+    glClear(GL_DEPTH_BUFFER_BIT);
     float ddpi = 96.0f;
     SDL_GetDisplayDPI(SDL_GetWindowDisplayIndex(_window), &ddpi, NULL, NULL);
     float scale = calculate_scale(width, height, ddpi);    
@@ -706,7 +805,10 @@ static void set_ninecraft_size(int width, int height) {
     }
 }
 
-static void resize_callback(struct SDL_Window *window, int width, int height) {
+static void resize_callback(struct SDL_Window *window) {
+    int width;
+    int height;
+    SDL_GL_GetDrawableSize(_window, &width, &height);
     if (version_id == version_id_0_1_0) {
         set_ninecraft_size_0_1_0(width, height);
     } else {
@@ -1666,7 +1768,7 @@ int main(int argc, char **argv) {
         "Ninecraft",
         SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
         720, 480,
-        SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE
+        SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI
     );
     if (!_window) {
         printf("SDL_CreateWindow Error: %s\n", SDL_GetError());
@@ -2100,11 +2202,7 @@ int main(int argc, char **argv) {
 
     mod_loader_execute_on_minecraft_init(ninecraft_app, version_id);
 
-    if (version_id >= version_id_0_1_0_touch) {
-        set_ninecraft_size(720, 480);
-    } else {
-        set_ninecraft_size_0_1_0(720, 480);
-    }
+    resize_callback(_window);
 
     if (version_id == version_id_0_11_1) {
         minecraft_isgrabbed_offset = MINECRAFTCLIENT_ISGRABBED_OFFSET_0_11_1;
@@ -2254,13 +2352,20 @@ int main(int argc, char **argv) {
             } else if (event.type == SDL_TEXTINPUT) {
                 char_callback(_window, event.text.text);
             } else if (event.type == SDL_MOUSEMOTION) {
-                mouse_pos_callback(_window, event.motion.x, event.motion.y, event.motion.xrel, event.motion.yrel);
+                if (event.motion.which != SDL_TOUCH_MOUSEID) {
+                    mouse_pos_callback(_window, event.motion.x, event.motion.y, event.motion.xrel, event.motion.yrel);
+                }
             } else if (event.type == SDL_MOUSEBUTTONDOWN || event.type == SDL_MOUSEBUTTONUP) {
-                mouse_click_callback(_window, event.button.button, event.button.state, event.button.x, event.button.y);
+                if (event.button.which != SDL_TOUCH_MOUSEID) {
+                    mouse_click_callback(_window, event.button.button, event.button.state, event.button.x, event.button.y);
+                }
             } else if (event.type == SDL_MOUSEWHEEL) {
                 mouse_scroll_callback(_window, event.wheel.preciseX, event.wheel.preciseY, event.wheel.direction);
+            } else if (event.type == SDL_FINGERDOWN || event.type == SDL_FINGERUP || event.type == SDL_FINGERMOTION) {
+                char id = touch_get_id(event.tfinger.touchId, event.tfinger.fingerId);
+                touch_callback(_window, event.tfinger.x, event.tfinger.y, event.tfinger.dx, event.tfinger.dy, event.type, id);
             } else if (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED) {
-                resize_callback(_window, event.window.data1, event.window.data2);
+                resize_callback(_window);
             }
         }
     }

--- a/ninecraft/src/main.c
+++ b/ninecraft/src/main.c
@@ -2385,8 +2385,16 @@ int main(int argc, char **argv) {
             } else if (event.type == SDL_FINGERDOWN || event.type == SDL_FINGERUP || event.type == SDL_FINGERMOTION) {
                 char id = touch_get_id(event.tfinger.touchId, event.tfinger.fingerId);
                 touch_callback(_window, event.tfinger.x, event.tfinger.y, event.tfinger.dx, event.tfinger.dy, event.type, id);
-            } else if (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED) {
-                resize_callback(_window);
+            } else if (event.type == SDL_WINDOWEVENT) {
+                if (event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED) {
+                    resize_callback(_window);
+                } else if (event.window.event == SDL_WINDOWEVENT_FOCUS_LOST) {
+                    // SDL_GetWindowGrab() always returns false when focus has been lost.
+                    if (SDL_GetRelativeMouseMode() == SDL_TRUE) {
+                        key_callback(_window, SDLK_ESCAPE, 0, SDL_KEYDOWN, KMOD_NONE);
+                        key_callback(_window, SDLK_ESCAPE, 0, SDL_KEYUP, KMOD_NONE);
+                    }
+                }
             }
         }
     }

--- a/ninecraft/src/ptpatch/apply.c
+++ b/ninecraft/src/ptpatch/apply.c
@@ -1,0 +1,104 @@
+#include <dirent.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <ninecraft/ptpatch/apply.h>
+#include <ninecraft/ptpatch/lib.h>
+
+// Copy File
+static FILE *copy_file(const char *src, const char *dst) {
+    // Open Files
+    FILE *src_file = fopen(src, "rb");
+    if (!src_file) {
+        return NULL;
+    }
+    FILE *dst_file = fopen(dst, "wb");
+    if (!dst_file) {
+        fclose(src_file);
+        return NULL;
+    }
+
+    // Copy File
+    fseek(src_file, 0, SEEK_END);
+    const size_t src_size = ftell(src_file);
+    fseek(src_file, 0, SEEK_SET);
+    int success = 1;
+    void *buf = NULL;
+    do {
+        buf = malloc(src_size);
+        if (!buf) {
+            success = 0;
+            break;
+        }
+        if (fread(buf, src_size, 1, src_file) != 1) {
+            success = 0;
+            break;
+        }
+        if (fwrite(buf, src_size, 1, dst_file) != 1) {
+            success = 0;
+            break;
+        }
+    } while (0);
+    free(buf);
+    fclose(src_file);
+    if (!success) {
+        fclose(dst_file);
+        return NULL;
+    }
+
+    // Return
+    return dst_file;
+}
+
+// Check If String Ends With Prefix
+static int ends_with(const char *str, const char *prefix) {
+    const size_t prefix_len = strlen(prefix);
+    const size_t str_len = strlen(str);
+    if (str_len < prefix_len) {
+        return 0;
+    }
+    return strncmp(str + (str_len - prefix_len), prefix, prefix_len) == 0;
+}
+
+// Patch Callback
+static void on_data(const off_t offset, const size_t data_length, unsigned char *data, void *user_data) {
+    FILE *file = user_data;
+    fseek(file, offset, SEEK_SET);
+    fwrite(data, data_length, 1, file);
+}
+
+// Apply Patches
+int apply_ptpatches(const char *src, const char *dst, const char *patches_dir) {
+    // Copy Files
+    FILE *dst_file = copy_file(src, dst);
+    if (!dst_file) {
+        return 0;
+    }
+
+    // Apply Patches
+    DIR *dir = opendir(patches_dir);
+    if (dir) {
+        struct dirent *entry;
+        while ((entry = readdir(dir)) != NULL) {
+            const char *name = entry->d_name;
+            if (ends_with(name, ".mod")) {
+                printf("Applying PTPatch: %s...", name);
+                int ret = 0;
+                char *patch_path = (char *)malloc(1024);
+                if (patch_path) {
+                    patch_path[0] = '\0';
+                    strcat(patch_path, patches_dir);
+                    strcat(patch_path, "/");
+                    strcat(patch_path, name);
+                    ret = load_patch(patch_path, NULL, on_data, dst_file) == PATCH_OK;
+                    free(patch_path);
+                }
+                printf(" %s\n", ret ? "Success" : "Failure");
+            }
+        }
+        closedir(dir);
+    }
+    fclose(dst_file);
+    return 1;
+}

--- a/ninecraft/src/ptpatch/lib.c
+++ b/ninecraft/src/ptpatch/lib.c
@@ -1,0 +1,103 @@
+#include <ninecraft/ptpatch/lib.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <arpa/inet.h>
+
+// Magic
+static const union {
+    unsigned char arr[4];
+    uint32_t num;
+} MAGIC = {
+    .arr = {0xff, 0x50, 0x54, 0x50}
+};
+
+// Macros
+#define ret(x) \
+    do { \
+        fclose(file); \
+        return (x); \
+    } while (0)
+#define safe_read(out) \
+    if (fread(&(out), sizeof(out), 1, file) != 1) { \
+        ret(PATCH_INVALID); \
+    } \
+    (void) 0
+#define fix_int(x) \
+    x = ntohl(x)
+
+// Load PTPatch
+patch_ret_t load_patch(const char *path, const patch_data_callback_t on_data, patch_apply_callback_t on_apply, void *user_data) {
+    // Open File
+    FILE *file = fopen(path, "rb");
+    if (!file) {
+        return PATCH_INVALID;
+    }
+
+    // Check Magic
+    uint32_t magic;
+    safe_read(magic);
+    if (magic != MAGIC.num) {
+        // Invalid Magic
+        ret(PATCH_INVALID);
+    }
+
+    // Read Metadata
+    patch_data_t meta;
+    unsigned char x;
+    safe_read(x);
+    meta.version_code = x;
+    safe_read(x);
+    meta.patch_count = x;
+    if (on_data && on_data(&meta, user_data)) {
+        ret(PATCH_SKIPPED);
+    }
+
+    // Read Patches
+    patch_ret_t ret = PATCH_OK;
+    for (int i = 0; i < meta.patch_count; i++) {
+        // Read Offset Of Patch In File
+        uint32_t offset;
+        safe_read(offset);
+        fix_int(offset);
+        const off_t next_index = ftell(file);
+        // Get Offset Of Next Patch In File
+        // Used To Determine Patch Size
+        uint32_t next_offset;
+        if (i == (meta.patch_count - 1)) {
+            fseek(file, 0, SEEK_END);
+            next_offset = ftell(file);
+        } else {
+            safe_read(next_offset);
+            fix_int(next_offset);
+        }
+        // Read Patch Address
+        fseek(file, (off_t) offset, SEEK_SET);
+        uint32_t addr;
+        safe_read(addr);
+        fix_int(addr);
+        // Read Patch Data
+        const off_t cursor = ftell(file);
+        if (next_offset > cursor) {
+            const size_t data_length = next_offset - cursor;
+            unsigned char *data = malloc(data_length);
+            if (!data || fread(data, data_length, 1, file) != 1) {
+                ret = PATCH_INVALID;
+            } else {
+                on_apply((off_t) addr, data_length, data, user_data);
+            }
+            free(data);
+        } else {
+            ret = PATCH_INVALID;
+        }
+        // Advance To Next Patch
+        if (ret == PATCH_OK) {
+            fseek(file, next_index, SEEK_SET);
+        } else {
+            break;
+        }
+    }
+
+    // Return
+    ret(ret);
+}


### PR DESCRIPTION
This contains all the changes I needed to get Ninecraft working nicely on my PinePhone Pro. Including:

- Multitouch support.
  - Obviously needed for phones.
  - This does not support 0.12.
- Support for running with Docker.
  - Certain OSes like postmarketOS (based on Alpine Linux) do not support multiarch. This means if your OS is 64-bit (very common), the OS will not provide 32-bit libraries.
  - In those cases, you will need a chroot.
  - Docker is one of the easiest ways to setup a chroot.
  - It's also nice to be able to install Ninecraft without polluting my FS with a bunch of 32-bit libraries.
- This also shows the pause menu when focus is lost.
   - Most mobile Linux distros don't have a back button (unfortunately) and MCPE does not have a pause button.
   - This is a hacky workaround that allows you to open the pause screen when you do not have a physical Escape key.
- Support for vibration motors.
  - My PinePhone Pro has an (admittedly not very good) vibration motor, might as well use it.
- Correctly hiding and showing the on-screen-keyboard when text inputs are selected.
- Proper support for building with system dependencies.
- I also added support for applying PTPatch patches because why not.
- Finally, I added fixes for building Ninecraft/`ancmp` on newer versions of Debian and 64-bit filesystems.

To do:
- I'm pretty sure my CMake changes broke one of the Nix patches, I need to fix that.
- I need to make my `ancmp` changes not rely on an internal `glibc` macro (see MFDGaming/ancmp#2).