### PR TITLE
WIP: Headless Ninecraft executable

### DIFF
--- a/ninecraft/CMakeLists.txt
+++ b/ninecraft/CMakeLists.txt
@@ -8,3 +8,10 @@ add_executable(ninecraft ${SOURCE_FILES} ../stb/stb_vorbis.c)
 target_include_directories(ninecraft PUBLIC include/)
 target_link_libraries(ninecraft ${CMAKE_DL_LIBS} zlibstatic SDL2::SDL2 SDL2main glad ancmp)
 include_directories(ninecraft PUBLIC include/)
+
+# Build server
+add_executable(ninecraft-headless ${SOURCE_FILES} ../stb/stb_vorbis.c)
+target_compile_definitions(ninecraft-headless PRIVATE NINECRAFT_HEADLESS)
+target_include_directories(ninecraft-headless PUBLIC include/)
+target_link_libraries(ninecraft-headless ${CMAKE_DL_LIBS} zlibstatic SDL2::SDL2 SDL2main glad ancmp)
+include_directories(ninecraft-headless PUBLIC include/)

--- a/ninecraft/include/ninecraft/game_parameters.h
+++ b/ninecraft/include/ninecraft/game_parameters.h
@@ -4,6 +4,12 @@
 typedef struct {
     char *home_path;
     char *game_path;
+    
+    // Server parameters
+    char *server_level_file;
+    char *server_motd;
+    int server_port;
+    int server_max_players;
 } game_parameters_t;
 
 extern game_parameters_t game_parameters;

--- a/ninecraft/include/ninecraft/minecraft.h
+++ b/ninecraft/include/ninecraft/minecraft.h
@@ -769,6 +769,10 @@ typedef void (*server_instance_start_server_t)(void *server_instance, android_st
 
 extern server_instance_start_server_t server_instance_start_server;
 
+typedef void (*minecraft_client_leave_game_t)(void *minecraft_client, bool return_to_title_screen);
+
+extern minecraft_client_leave_game_t minecraft_client_leave_game;
+
 extern void minecraft_setup_hooks(void *handle);
 
 #endif

--- a/ninecraft/include/ninecraft/minecraft.h
+++ b/ninecraft/include/ninecraft/minecraft.h
@@ -570,6 +570,22 @@
 #define MINECRAFT_ISGRABBED_OFFSET_0_1_0_TOUCH 0xd38
 #define MINECRAFT_ISGRABBED_OFFSET_0_1_0 0xd28
 
+#if defined(__i386__) || defined(_M_IX86)
+#define EXTERNALLEVELSTORAGE_SIZE_0_11_1 0x8
+#else
+#if defined(__arm__) || defined(_M_ARM)
+#define EXTERNALLEVELSTORAGE_SIZE_0_11_1 0x8 // TODO: Correct this
+#endif
+#endif
+
+#if defined(__i386__) || defined(_M_IX86)
+#define SERVERINSTANCE_SIZE_0_11_1 0x18
+#else
+#if defined(__arm__) || defined(_M_ARM)
+#define SERVERINSTANCE_SIZE_0_11_1 0x18 // TODO: Correct this
+#endif
+#endif
+
 extern void gui_component_draw_rect(void *gui_component, int x1, int y1, int x2, int y2, int color, int thickness);
 
 extern void *minecraft_get_options(void *minecraft, int version_id);
@@ -577,6 +593,10 @@ extern void *minecraft_get_options(void *minecraft, int version_id);
 extern uintptr_t get_ninecraftapp_external_storage_offset(int version_id);
 
 extern uintptr_t get_ninecraftapp_internal_storage_offset(int version_id);
+
+extern size_t get_external_level_storage_size(int version_id);
+
+extern size_t get_server_instance_size(int version_id);
 
 typedef void (*minecraft_level_generated_t)(void *minecraft);
 
@@ -732,6 +752,22 @@ extern minecraft_client_get_local_player_t minecraft_client_get_local_player;
 
 typedef void (*gui_component_fill_t)(void *gui_component, int x1, int y1, int x2, int y2, int color);
 extern gui_component_fill_t gui_component_fill;
+
+typedef void (*external_level_storage_construct_t)(void *external_file_level_storage_source, android_string_t *storage_path);
+
+extern external_level_storage_construct_t external_level_storage_construct;
+
+typedef void (*server_instance_construct_t)(void *server_instance, void *external_file_level_storage_source);
+
+extern server_instance_construct_t server_instance_construct;
+
+typedef void (*server_instance_load_level_t)(void *server_instance, android_string_t *level_path, android_string_t *level_name, void *level_settings);
+
+extern server_instance_load_level_t server_instance_load_level;
+
+typedef void (*server_instance_start_server_t)(void *server_instance, android_string_t *motd, int port, int max_players);
+
+extern server_instance_start_server_t server_instance_start_server;
 
 extern void minecraft_setup_hooks(void *handle);
 

--- a/ninecraft/src/AppPlatform_linux.c
+++ b/ninecraft/src/AppPlatform_linux.c
@@ -1197,25 +1197,41 @@ android_string_t *AppPlatform_linux$getSystemRegion(AppPlatform_linux *app_platf
 SYSV_WRAPPER(AppPlatform_linux$getGraphicsVendor, 2)
 void AppPlatform_linux$getGraphicsVendor(android_string_t *ret, AppPlatform_linux *app_platform) {
     //puts("debug: AppPlatform_linux::getGraphicsVendor");
+#ifndef NINECRAFT_HEADLESS
     android_string_cstr(ret, (char *)glGetString(GL_VENDOR));
+#else
+    android_string_cstr(ret, "null");
+#endif
 }
 
 SYSV_WRAPPER(AppPlatform_linux$getGraphicsRenderer, 2)
 void AppPlatform_linux$getGraphicsRenderer(android_string_t *ret, AppPlatform_linux *app_platform) {
     //puts("debug: AppPlatform_linux::getGraphicsRenderer");
+#ifndef NINECRAFT_HEADLESS
     android_string_cstr(ret, (char *)glGetString(GL_RENDERER));
+#else
+    android_string_cstr(ret, "null");
+#endif
 }
 
 SYSV_WRAPPER(AppPlatform_linux$getGraphicsVersion, 2)
 void AppPlatform_linux$getGraphicsVersion(android_string_t *ret, AppPlatform_linux *app_platform) {
     //puts("debug: AppPlatform_linux::getGraphicsVersion");
+#ifndef NINECRAFT_HEADLESS
     android_string_cstr(ret, (char *)glGetString(GL_VERSION));
+#else
+    android_string_cstr(ret, "null");
+#endif
 }
 
 SYSV_WRAPPER(AppPlatform_linux$getGraphicsExtensions, 2)
 void AppPlatform_linux$getGraphicsExtensions(android_string_t *ret, AppPlatform_linux *app_platform) {
     //puts("debug: AppPlatform_linux::getGraphicsExtensions");
+#ifndef NINECRAFT_HEADLESS
     android_string_cstr(ret, (char *)glGetString(GL_EXTENSIONS));
+#else
+    android_string_cstr(ret, "null");
+#endif
 }
 
 android_string_t *AppPlatform_linux$getExternalStoragePath(AppPlatform_linux *app_platform) {

--- a/ninecraft/src/game_parameters.c
+++ b/ninecraft/src/game_parameters.c
@@ -9,8 +9,12 @@
 #endif
 
 game_parameters_t game_parameters = {
-    (char *)NULL,
-    (char *)NULL
+    (char *)NULL,   // home_path
+    (char *)NULL,   // game_path
+    (char *)NULL,   // server_level_file
+    (char *)NULL,   // server_motd
+    -1,             // server_port
+    -1,             // server_max_players
 };
 
 static char cwd_path[1024];
@@ -27,10 +31,46 @@ void parse_game_parameters(int argc, char **argv) {
             if (++i < argc) {
                 game_parameters.home_path = argv[i];
             }
+#ifdef NINECRAFT_HEADLESS
+        } else if (!strcmp(argv[i], "--level")) {
+            if (++i < argc) {
+                game_parameters.server_level_file = argv[i];
+            }
+        } else if (!strcmp(argv[i], "--motd")) {
+            if (++i < argc) {
+                game_parameters.server_motd = argv[i];
+            }
+        } else if (!strcmp(argv[i], "--port")) {
+            if (++i < argc) {
+                int port = atoi(argv[i]);
+                if (port > 65535 || port < 1) {
+                    printf("Port must be between 1 and 65535\n");
+                    exit(1);
+                }
+                game_parameters.server_port = port;
+            }
+        } else if (!strcmp(argv[i], "--max-players")) {
+            if (++i < argc) {
+                int max_players = atoi(argv[i]);
+                if (max_players < 1) {
+                    printf("Max players must at least be 1\n");
+                    exit(1);
+                } else if (max_players > 65535) {
+                    printf("Warning: max players has been set to a value greater than 65535. Expect errors\n");
+                }
+                game_parameters.server_max_players = max_players;
+            }
+#endif
         } else if (!strcmp(argv[i], "--help")) {
             printf("%s <args...>\n", argv[0]);
             printf("--home <path>: specifies the path to the userdata directory\n");
             printf("--game <path>: specifies the path to the gamedata directory\n");
+#ifdef NINECRAFT_HEADLESS
+            printf("--level <path>: specifies the file name of the level to host\n");
+            printf("--motd <motd>: specifies the text to display as the server MOTD\n");
+            printf("--port <port>: specifies what port to listen on (default: 19132)\n");
+            printf("--max-players <count>: specifies the maximum player count (default: 10)\n");
+#endif
             printf("--help: prints the usage of the command line arguments\n");
             exit(0);
         }
@@ -41,4 +81,19 @@ void parse_game_parameters(int argc, char **argv) {
     if (!game_parameters.home_path) {
         game_parameters.home_path = cwd_path;
     }
+#ifdef NINECRAFT_HEADLESS
+    if (!game_parameters.server_level_file) {
+        printf("Error: Level file name must be specified\n");
+        exit(1);
+    }
+    if (!game_parameters.server_motd) {
+        game_parameters.server_motd = "Ninecraft Server";
+    }
+    if (game_parameters.server_port == -1) {
+        game_parameters.server_port = 19132;
+    }
+    if (game_parameters.server_max_players == -1) {
+        game_parameters.server_max_players = 10;
+    }
+#endif
 }

--- a/ninecraft/src/gfx/gles_compat_null.c
+++ b/ninecraft/src/gfx/gles_compat_null.c
@@ -1,387 +1,388 @@
 #include <ninecraft/gfx/gles_compat.h>
 
-#ifndef NINECRAFT_HEADLESS
+#ifdef NINECRAFT_HEADLESS
 FLOAT_ABI_FIX void gl_alpha_func(GLenum func, GLclampf ref) {
-    glAlphaFunc(func, ref);
+    return;
 }
 
 void gl_bind_buffer(GLenum target, GLuint buffer) {
-    glBindBuffer(target, buffer);
+    return;
 }
 
 void gl_bind_texture(GLenum target, GLuint texture) {
-    glBindTexture(target, texture);
+    return;
 }
 
 void gl_blend_func(GLenum sfactor, GLenum dfactor) {
-    glBlendFunc(sfactor, dfactor);
+    return;
 }
 
 void gl_buffer_data(GLenum target, GLsizeiptr size, const void *data, GLenum usage) {
-    glBufferData(target, size, data, usage);
+    return;
 }
 
 void gl_clear(GLbitfield mask) {
-    glClear(mask);
+    return;
 }
 
 FLOAT_ABI_FIX void gl_clear_color(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha) {
-    glClearColor(red, green, blue, alpha);
+    return;
 }
 
 FLOAT_ABI_FIX void gl_color_4_f(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha) {
-    glColor4f(red, green, blue, alpha);
+    return;
 }
 
 void gl_color_mask(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha) {
-    glColorMask(red, green, blue, alpha);
+    return;
 }
 
 void gl_color_pointer(GLint size, GLenum type, GLsizei stride, const void *pointer) {
-    glColorPointer(size, type, stride, pointer);
+    return;
 }
 
 void gl_cull_face(GLenum mode) {
-    glCullFace(mode);
+    return;
 }
 
 void gl_delete_buffers(GLsizei n, const GLuint *buffers) {
-    glDeleteBuffers(n, buffers);
+    return;
 }
 
 void gl_delete_textures(GLsizei n, const GLuint *textures) {
-    glDeleteTextures(n, textures);
+    return;
 }
 
 void gl_depth_func(GLenum func) {
-    glDepthFunc(func);
+    return;
 }
 
 void gl_depth_mask(GLboolean flag) {
-    glDepthMask(flag);
+    return;
 }
 
 FLOAT_ABI_FIX void gl_depth_range_f(GLclampf near, GLclampf far) {
-    glDepthRange((GLclampd)near, (GLclampd)far);
+    return;
 }
 
 void gl_disable(GLenum cap) {
-    glDisable(cap);
+    return;
 }
 
 void gl_disable_client_state(GLenum array) {
-    glDisableClientState(array);
+    return;
 }
 
 void gl_draw_arrays(GLenum mode, GLint first, GLsizei count) {
-    glDrawArrays(mode, first, count);
+    return;
 }
 
 void gl_enable(GLenum cap) {
-    glEnable(cap);
+    return;
 }
 
 void gl_enable_client_state(GLenum array) {
-    glEnableClientState(array);
+    return;
 }
 
 FLOAT_ABI_FIX void gl_fog_f(GLenum pname, GLfloat param) {
-    glFogf(pname, param);
+    return;
 }
 
 FLOAT_ABI_FIX void gl_fog_f_v(GLenum pname, const GLfloat *params) {
-    glFogfv(pname, params);
+    return;
 }
 
 void gl_fog_x(GLenum pname, GLfixed param) {
-    glFogi(pname, param);
+    return;
 }
 
 void gl_gen_textures(GLsizei n, GLuint *textures) {
-    glGenTextures(n, textures);
+    return;
 }
 
 FLOAT_ABI_FIX void gl_get_float_v(GLenum pname, GLfloat *params) {
-    glGetFloatv(pname, params);
+    return;
 }
 
 const GLubyte *gl_get_string(GLenum name) {
-    return glGetString(name);
+    return NULL;
 }
 
 void gl_hint(GLenum target, GLenum mode) {
-    glHint(target, mode);
+    return;
 }
 
 FLOAT_ABI_FIX void gl_line_width(GLfloat width) {
-    glLineWidth(width);
+    return;
 }
 
 void gl_load_identity() {
-    glLoadIdentity();
+    return;
 }
 
 void gl_matrix_mode(GLenum mode) {
-    glMatrixMode(mode);
+    return;
 }
 
 FLOAT_ABI_FIX void gl_mult_matrix_f(const GLfloat *m) {
-    glMultMatrixf(m);
+    return;
 }
 
 FLOAT_ABI_FIX void gl_normal_3_f(GLfloat nx, GLfloat ny, GLfloat nz) {
-    glNormal3f(nx, ny, nz);
+    return;
 }
 
 FLOAT_ABI_FIX void gl_ortho_f(GLfloat left, GLfloat right, GLfloat bottom, GLfloat top, GLfloat near, GLfloat far) {
-    glOrtho((GLdouble)left, (GLdouble)right, (GLdouble)bottom, (GLdouble)top, (GLdouble)near, (GLdouble)far);
+    return;
 }
 
 FLOAT_ABI_FIX void gl_polygon_offset(GLfloat factor, GLfloat units) {
-    glPolygonOffset(factor, units);
+    return;
 }
 
 void gl_pop_matrix() {
-    glPopMatrix();
+    return;
 }
 
 void gl_push_matrix() {
-    glPushMatrix();
+    return;
 }
 
 void gl_read_pixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, GLvoid *pixels) {
-    glReadPixels(x, y, width, height, format, type, pixels);
+    return;
 }
 
 FLOAT_ABI_FIX void gl_rotate_f(GLfloat angle, GLfloat x, GLfloat y, GLfloat z) {
-    glRotatef(angle, x, y, z);
+    return;
 }
 
 FLOAT_ABI_FIX void gl_scale_f(GLfloat x, GLfloat y, GLfloat z) {
-    glScalef(x, y, z);
+    return;
 }
 
 void gl_scissor(GLint x, GLint y, GLsizei width, GLsizei height) {
-    glScissor(x, y, width, height);
+    return;
 }
 
 void gl_shade_model(GLenum mode) {
-    glShadeModel(mode);
+    return;
 }
 
 void gl_tex_coord_pointer(GLint size, GLenum type, GLsizei stride, const GLvoid *pointer) {
-    glTexCoordPointer(size, type, stride, pointer);
+    return;
 }
 
 void gl_tex_image_2_d(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const GLvoid *pixels) {
-    glTexImage2D(target, level, internalformat, width, height, border, format, type, pixels);
+    return;
 }
 
 void gl_tex_parameter_i(GLenum target, GLenum pname, GLint param) {
-    glTexParameteri(target, pname, param);
+    return;
 }
 
 void gl_tex_sub_image_2_d(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, const GLvoid *pixels) {
-    glTexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels);
+    return;
 }
 
 FLOAT_ABI_FIX void gl_translate_f(GLfloat x, GLfloat y, GLfloat z) {
-    glTranslatef(x, y, z);
+    return;
 }
 
 void gl_vertex_pointer(GLint size, GLenum type, GLsizei stride, const GLvoid *pointer) {
-    glVertexPointer(size, type, stride, pointer);
+    return;
 }
 
 void gl_viewport(GLint x, GLint y, GLsizei width, GLsizei height) {
-    glViewport(x, y, width, height);
+    return;
 }
 
 void gl_draw_elements(GLenum mode, GLsizei count, GLenum type, const void *indices) {
-    glDrawElements(mode, count, type, indices);
+    return;
 }
 
 GLenum gl_get_error() {
-    return glGetError();
+    // For some reason this has to be 1 or Minecraft will crash
+    return 1;
 }
 
 void gl_gen_buffers(GLsizei n, GLuint *buffers) {
-    glGenBuffers(n, buffers);
+    return;
 }
 
 void gl_stencil_func(GLenum func, GLint ref, GLuint mask) {
-    glStencilFunc(func, ref, mask);
+    return;
 }
 
 void gl_stencil_mask(GLuint mask) {
-    glStencilMask(mask);
+    return;
 }
 
 FLOAT_ABI_FIX void gl_light_model_f(GLenum pname, GLfloat param) {
-    glLightModelf(pname, param);
+    return;
 }
 
 FLOAT_ABI_FIX void gl_light_f_v(GLenum light, GLenum pname, const GLfloat *params) {
-    glLightfv(light, pname, params);
+    return;
 }
 
 void gl_normal_pointer(GLenum type, GLsizei stride, const GLvoid *pointer) {
-    glNormalPointer(type, stride, pointer);
+    return;
 }
 
 void gl_stencil_op(GLenum fail, GLenum zfail, GLenum zpass) {
-    glStencilOp(fail, zfail, zpass);
+    return;
 }
 
 void gl_active_texture(GLenum texture) {
-    glActiveTexture(texture);
+    return;
 }
 
 void gl_attach_shader(GLuint program, GLuint shader) {
-    glAttachShader(program, shader);
+    return;
 }
 
 void gl_clear_stencil(GLint s) {
-    glClearStencil(s);
+    return;
 }
 
 void gl_compile_shader(GLuint shader) {
-    glCompileShader(shader);
+    return;
 }
 
 GLuint gl_create_program() {
-    return glCreateProgram();
+    return 0;
 }
 
 GLuint gl_create_shader(GLenum type) {
-    return glCreateShader(type);
+    return 0;
 }
 
 void gl_delete_program(GLuint program) {
-    glDeleteProgram(program);
+    return;
 }
 
 void gl_enable_vertex_attrib_array(GLuint index) {
-    glEnableVertexAttribArray(index);
+    return;
 }
 
 void gl_get_active_attrib(GLuint program, GLuint index, GLsizei bufSize, GLsizei *length, GLint *size, GLenum *type, GLchar *name) {
-    glGetActiveAttrib(program, index, bufSize, length, size, type, name);
+    return;
 }
 
 void gl_get_active_uniform(GLuint program, GLuint index, GLsizei bufSize, GLsizei *length, GLint *size, GLenum *type, GLchar *name) {
-    glGetActiveUniform(program, index, bufSize, length, size, type, name);
+    return;
 }
 
 GLint gl_get_attrib_location(GLuint program, const GLchar *name) {
-    return glGetAttribLocation(program, name);
+    return 0;
 }
 
 void gl_get_program_info_log(GLuint program, GLsizei bufSize, GLsizei *length, GLchar *infoLog) {
-    glGetProgramInfoLog(program, bufSize, length, infoLog);
+    return;
 }
 
 void gl_get_program_i_v(GLuint program, GLenum pname, GLint *params) {
-    glGetProgramiv(program, pname, params);
+    return;
 }
 
 void gl_get_shader_info_log(GLuint shader, GLsizei bufSize, GLsizei *length, GLchar *infoLog) {
-    glGetShaderInfoLog(shader, bufSize, length, infoLog);
+    return;
 }
 
 void gl_get_shader_i_v(GLuint shader, GLenum pname, GLint *params) {
-    glGetShaderiv(shader, pname, params);
+    return;
 }
 
 void gl_get_shader_precision_format(GLenum shadertype, GLenum precisiontype, GLint *range, GLint *precision) {
-    glGetShaderPrecisionFormat(shadertype, precisiontype, range, precision);
+    return;
 }
 
 GLint gl_get_uniform_location(GLuint program, const GLchar *name) {
-    return glGetUniformLocation(program, name);
+    return 0;
 }
 
 void gl_link_program(GLuint program) {
-    glLinkProgram(program);
+    return;
 }
 
 void gl_release_shader_compiler() {
-    glReleaseShaderCompiler();
+    return;
 }
 
 void gl_shader_source(GLuint shader, GLsizei count, const GLchar *const *string, const GLint *length) {
-    glShaderSource(shader, count, string, length);
+    return;
 }
 
 FLOAT_ABI_FIX void gl_uniform_1_f_v(GLint location, GLsizei count, const GLfloat *value) {
-    glUniform1fv(location, count, value);
+    return;
 }
 
 void gl_uniform_1_i_v(GLint location, GLsizei count, const GLint *value) {
-    glUniform1iv(location, count, value);
+    return;
 }
 
 FLOAT_ABI_FIX void gl_uniform_2_f_v(GLint location, GLsizei count, const GLfloat *value) {
-    glUniform2fv(location, count, value);
+    return;
 }
 
 void gl_uniform_2_i_v(GLint location, GLsizei count, const GLint *value) {
-    glUniform2iv(location, count, value);
+    return;
 }
 
 FLOAT_ABI_FIX void gl_uniform_3_f_v(GLint location, GLsizei count, const GLfloat *value) {
-    glUniform3fv(location, count, value);
+    return;
 }
 
 void gl_uniform_3_i_v(GLint location, GLsizei count, const GLint *value) {
-    glUniform3iv(location, count, value);
+    return;
 }
 
 FLOAT_ABI_FIX void gl_uniform_4_f_v(GLint location, GLsizei count, const GLfloat *value) {
-    glUniform4fv(location, count, value);
+    return;
 }
 
 void gl_uniform_4_i_v(GLint location, GLsizei count, const GLint *value) {
-    glUniform4iv(location, count, value);
+    return;
 }
 
 FLOAT_ABI_FIX void gl_uniform_matrix_2_f_v(GLint location, GLsizei count, GLboolean transpose, const GLfloat *value) {
-    glUniformMatrix2fv(location, count, transpose, value);
+    return;
 }
 
 FLOAT_ABI_FIX void gl_uniform_matrix_3_f_v(GLint location, GLsizei count, GLboolean transpose, const GLfloat *value) {
-    glUniformMatrix3fv(location, count, transpose, value);
+    return;
 }
 
 FLOAT_ABI_FIX void gl_uniform_matrix_4_f_v(GLint location, GLsizei count, GLboolean transpose, const GLfloat *value) {
-    glUniformMatrix4fv(location, count, transpose, value);
+    return;
 }
 
 void gl_use_program(GLuint program) {
-    glUseProgram(program);
+    return;
 }
 
 void gl_vertex_attrib_pointer(GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const void *pointer) {
-    glVertexAttribPointer(index, size, type, normalized, stride, pointer);
+    return;
 }
 
 void gl_stencil_func_separate(GLenum face, GLenum func, GLint ref, GLuint mask) {
-    glStencilFuncSeparate(face, func, ref, mask);
+    return;
 }
 
 void gl_stencil_op_separate(GLenum face, GLenum sfail, GLenum dpfail, GLenum dppass) {
-    glStencilOpSeparate(face, sfail, dpfail, dppass);
+    return;
 }
 
 void gl_delete_shader(GLuint shader) {
-    glDeleteShader(shader);
+    return;
 }
 
 void gl_uniform_1_i(GLint location, GLint v0) {
-    glUniform1i(location, v0);
+    return;
 }
 
 void gl_buffer_sub_data(GLenum target, GLintptr offset, GLsizeiptr size, const void *data) {
-    glBufferSubData(target, offset, size, data);
+    return;
 }
 #endif

--- a/ninecraft/src/main.c
+++ b/ninecraft/src/main.c
@@ -1,3 +1,4 @@
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1411,6 +1412,11 @@ bool get_level_name(char *storage_path, char *level_file_name, char *level_name,
     return true;
 }
 
+volatile sig_atomic_t sigstop = 0;
+void sighandler(int sigid) {
+    sigstop = 1;
+}
+
 int main(int argc, char **argv) {
     struct soinfo *so_liblog, *so_libgles, *so_libgles2, *so_libegl;
     struct soinfo *so_libandroid, *so_libopensles, *so_libz;
@@ -1425,6 +1431,9 @@ int main(int argc, char **argv) {
     void *icon_pixels, *server_instance;
 #ifdef NINECRAFT_HEADLESS
     char server_level_name[1024];
+    
+    signal(SIGTERM, sighandler);
+    signal(SIGINT, sighandler);
 #endif
     
     parse_game_parameters(argc, argv);
@@ -2082,6 +2091,10 @@ int main(int argc, char **argv) {
                 resize_callback(_window, event.window.data1, event.window.data2);
             }
         }
+#else
+        if (sigstop) {
+            running = false;
+        }
 #endif
     }
 #ifndef NINECRAFT_HEADLESS
@@ -2089,6 +2102,9 @@ int main(int argc, char **argv) {
     SDL_GL_DeleteContext(gl_context);
     SDL_DestroyWindow(_window);
     SDL_Quit();
+#else
+    printf("Stopping server...\n");
+    minecraft_client_leave_game(ninecraft_app, false);
 #endif
     free(storage_path);
     free(mods_path);

--- a/ninecraft/src/main.c
+++ b/ninecraft/src/main.c
@@ -1568,8 +1568,6 @@ int main(int argc, char **argv) {
     so_libz = android_library_create("libz.so");
 
     handle = load_library("libminecraftpe.so");
-    long baseOffset = (long)(void*)android_dlsym(handle, "_ZN4AABBC1Ev") - 0x00337cf0;
-    printf("Base offset is: %p\n", baseOffset);
     
     if (!handle) {
         puts("libminecraftpe.so not loaded");

--- a/ninecraft/src/main.c
+++ b/ninecraft/src/main.c
@@ -1421,6 +1421,7 @@ int main(int argc, char **argv) {
     strncat(ovc_path, game_parameters.home_path, 1023);
     strncat(ovc_path, "/options.txt", 1023);
 
+#ifndef NINECRAFT_HEADLESS
     icon_path = (char *)malloc(1024);
     if (!icon_path) {
         puts("out of memory");
@@ -1433,7 +1434,8 @@ int main(int argc, char **argv) {
     icon_path[0] = '\0';
     strncat(icon_path, game_parameters.game_path, 1023);
     strncat(icon_path, "/res/drawable/iconx.png", 1023);
-
+#endif
+    
     if (stat(game_parameters.home_path, &st) == -1) {
         mkdir(game_parameters.home_path, 0700);
     }
@@ -1455,6 +1457,7 @@ int main(int argc, char **argv) {
 
     android_linker_init();
 
+#ifndef NINECRAFT_HEADLESS
     if (SDL_Init(SDL_INIT_VIDEO) < 0) {
         printf("SDL_Init Error: %s\n", SDL_GetError());
         free(storage_path);
@@ -1520,7 +1523,8 @@ int main(int argc, char **argv) {
     gladLoadGL((GLADloadfunc)SDL_GL_GetProcAddress);
 
     audio_engine_init();
-
+#endif
+    
     gles_hook();
     missing_hook();
     add_custom_hook("__android_log_print", (void *)__android_log_print);
@@ -1958,6 +1962,7 @@ int main(int argc, char **argv) {
     }
     
     while (running) {
+#ifndef NINECRAFT_HEADLESS
         if (((bool *)ninecraft_app)[minecraft_isgrabbed_offset]) {
             if (!mouse_pointer_hidden) {
                 grab_mouse();
@@ -1967,6 +1972,7 @@ int main(int argc, char **argv) {
                 release_mouse();
             }
         }
+#endif
         if (version_id >= version_id_0_6_0 && version_id <= version_id_0_8_1) {
             if (minecraft_is_level_generated(ninecraft_app)) {
                 if (!mcpi_api_initialized) {
@@ -1994,6 +2000,7 @@ int main(int argc, char **argv) {
 #endif
         mod_loader_execute_on_minecraft_update(ninecraft_app, version_id);
 
+#ifndef NINECRAFT_HEADLESS
         audio_engine_tick();
         SDL_GL_SwapWindow(_window);
 
@@ -2014,11 +2021,14 @@ int main(int argc, char **argv) {
                 resize_callback(_window, event.window.data1, event.window.data2);
             }
         }
+#endif
     }
+#ifndef NINECRAFT_HEADLESS
     audio_engine_destroy();
     SDL_GL_DeleteContext(gl_context);
     SDL_DestroyWindow(_window);
     SDL_Quit();
+#endif
     free(storage_path);
     free(mods_path);
     free(global_overrides_path);

--- a/ninecraft/src/main.c
+++ b/ninecraft/src/main.c
@@ -1386,6 +1386,31 @@ void *init_server(int version_id, char *storage_path, char *level_path, char *le
     return server_instance;
 }
 
+bool get_level_name(char *storage_path, char *level_file_name, char *level_name, int level_name_size) {
+    char *level_name_path;
+    FILE *f;
+    struct stat file_stat;
+    int c;
+
+    level_name_path = (char *)malloc(1024);
+    level_name_path[0] = '\0';
+    strcat(level_name_path, storage_path);
+    strcat(level_name_path, "/games/com.mojang/minecraftWorlds/");
+    strcat(level_name_path, level_file_name);
+    strcat(level_name_path, "/levelname.txt");
+    
+    if (stat(level_name_path, &file_stat) != 0) {
+        strcpy(level_name, "null");
+        return false;
+    }
+    
+    f = fopen(level_name_path, "r");
+    c = fread(level_name, sizeof(char), level_name_size, f);
+    level_name[c] = '\0';
+    fclose(f);
+    return true;
+}
+
 int main(int argc, char **argv) {
     struct soinfo *so_liblog, *so_libgles, *so_libgles2, *so_libegl;
     struct soinfo *so_libandroid, *so_libopensles, *so_libz;
@@ -1398,7 +1423,10 @@ int main(int argc, char **argv) {
     SDL_Event event;
     char *minecraft_options;
     void *icon_pixels, *server_instance;
-
+#ifdef NINECRAFT_HEADLESS
+    char server_level_name[1024];
+#endif
+    
     parse_game_parameters(argc, argv);
 
     storage_path = (char *)malloc(1024);
@@ -1880,7 +1908,13 @@ int main(int argc, char **argv) {
     mod_loader_execute_on_minecraft_init(ninecraft_app, version_id);
     
 #ifdef NINECRAFT_HEADLESS
-    server_instance = init_server(version_id, storage_path, "Sh0AAKocAAA=", "Server level", "Some MOTD", 19132, 10);
+    if (!get_level_name(storage_path, game_parameters.server_level_file, server_level_name, sizeof(server_level_name) / sizeof(char))) {
+        printf("Could not find level by file name '%s'. (Must be file name, and not level name or file path)\n", game_parameters.server_level_file);
+        exit(1);
+    }
+    
+    server_instance = init_server(version_id, storage_path, game_parameters.server_level_file, server_level_name, game_parameters.server_motd,
+        game_parameters.server_port, game_parameters.server_max_players);
     *(void **)((char *)ninecraft_app + 0x15c) = server_instance; // serverInstance
 #endif
     

--- a/ninecraft/src/main.c
+++ b/ninecraft/src/main.c
@@ -5,6 +5,7 @@
 #include <stdarg.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <unistd.h>
 #ifndef _WIN32
 #include <sys/mman.h>
 #else
@@ -1364,6 +1365,39 @@ static bool detect_version() {
     return found;
 }
 
+
+#define CALL(symbol, ret, ...) ((ret(*)(__VA_ARGS__))android_dlsym(handle, symbol))
+#define CALLV(obj, off, ret, ...) ((ret(*)(__VA_ARGS__))(*(void**)(*(char**)obj + off)))
+
+typedef void ExternalFileLevelStorageSource;
+typedef void ServerInstance;
+typedef void AppPlatform;
+typedef void LevelSettings;
+typedef void MinecraftClient;
+
+ServerInstance* server;
+void init_server(int version_id, char *storage_path) {
+    android_string_t storageRoot;
+    android_string_cstr(&storageRoot, storage_path);
+    
+    android_string_t levelFile, levelName, serverName;
+    android_string_cstr(&levelFile, "Sh0AAKocAAA=");
+    android_string_cstr(&levelName, "Creative test");
+    android_string_cstr(&serverName, "Example motd");
+    
+    ExternalFileLevelStorageSource* source = malloc(get_external_level_storage_size(version_id));
+    external_level_storage_construct(source, &storageRoot);
+    server = malloc(get_server_instance_size(version_id));
+    server_instance_construct(server, source);
+    int settings = -1;
+    server_instance_load_level(server, &levelFile, &levelName, &settings);
+    server_instance_start_server(server, &serverName, 19132, 10);
+}
+
+void tick_server() {
+    CALL("_ZN14ServerInstance4tickEv", void, ServerInstance*)(server);
+}
+
 int main(int argc, char **argv) {
     struct soinfo *so_liblog, *so_libgles, *so_libgles2, *so_libegl;
     struct soinfo *so_libandroid, *so_libopensles, *so_libz;
@@ -1546,7 +1580,9 @@ int main(int argc, char **argv) {
     so_libz = android_library_create("libz.so");
 
     handle = load_library("libminecraftpe.so");
-
+    long baseOffset = (long)(void*)android_dlsym(handle, "_ZN4AABBC1Ev") - 0x00337cf0;
+    printf("Base offset is: %p\n", baseOffset);
+    
     if (!handle) {
         puts("libminecraftpe.so not loaded");
         free(storage_path);
@@ -1856,7 +1892,12 @@ int main(int argc, char **argv) {
     }
 
     mod_loader_execute_on_minecraft_init(ninecraft_app, version_id);
-
+    
+#ifdef NINECRAFT_HEADLESS
+    init_server(version_id, storage_path);
+    *(void **)((char *)ninecraft_app + 0x15c) = server; // serverInstance
+#endif
+    
     if (version_id >= version_id_0_1_0_touch) {
         set_ninecraft_size(720, 480);
     } else {
@@ -2003,7 +2044,7 @@ int main(int argc, char **argv) {
 #ifndef NINECRAFT_HEADLESS
         audio_engine_tick();
         SDL_GL_SwapWindow(_window);
-
+        
         while (SDL_PollEvent(&event)) {
             if (event.type == SDL_QUIT) {
                 running = false;

--- a/ninecraft/src/main.c
+++ b/ninecraft/src/main.c
@@ -5,7 +5,6 @@
 #include <stdarg.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <unistd.h>
 #ifndef _WIN32
 #include <sys/mman.h>
 #else
@@ -1365,37 +1364,26 @@ static bool detect_version() {
     return found;
 }
 
-
-#define CALL(symbol, ret, ...) ((ret(*)(__VA_ARGS__))android_dlsym(handle, symbol))
-#define CALLV(obj, off, ret, ...) ((ret(*)(__VA_ARGS__))(*(void**)(*(char**)obj + off)))
-
-typedef void ExternalFileLevelStorageSource;
-typedef void ServerInstance;
-typedef void AppPlatform;
-typedef void LevelSettings;
-typedef void MinecraftClient;
-
-ServerInstance* server;
-void init_server(int version_id, char *storage_path) {
-    android_string_t storageRoot;
-    android_string_cstr(&storageRoot, storage_path);
+void *init_server(int version_id, char *storage_path, char *level_path, char *level_name, char *motd, int port, int max_players) {
+    void *external_storage_source, *server_instance;
+    int level_settings;
+    android_string_t storage_path_an, level_path_an, level_name_an, motd_an;
     
-    android_string_t levelFile, levelName, serverName;
-    android_string_cstr(&levelFile, "Sh0AAKocAAA=");
-    android_string_cstr(&levelName, "Creative test");
-    android_string_cstr(&serverName, "Example motd");
+    android_string_cstr(&storage_path_an, storage_path);
+    android_string_cstr(&level_path_an, level_path);
+    android_string_cstr(&level_name_an, level_name);
+    android_string_cstr(&motd_an, motd);
     
-    ExternalFileLevelStorageSource* source = malloc(get_external_level_storage_size(version_id));
-    external_level_storage_construct(source, &storageRoot);
-    server = malloc(get_server_instance_size(version_id));
-    server_instance_construct(server, source);
-    int settings = -1;
-    server_instance_load_level(server, &levelFile, &levelName, &settings);
-    server_instance_start_server(server, &serverName, 19132, 10);
-}
-
-void tick_server() {
-    CALL("_ZN14ServerInstance4tickEv", void, ServerInstance*)(server);
+    external_storage_source = malloc(get_external_level_storage_size(version_id));
+    external_level_storage_construct(external_storage_source, &storage_path_an);
+    
+    server_instance = malloc(get_server_instance_size(version_id));
+    server_instance_construct(server_instance, external_storage_source);
+    
+    level_settings = -1;
+    server_instance_load_level(server_instance, &level_path_an, &level_name_an, &level_settings);
+    server_instance_start_server(server_instance, &motd_an, port, max_players);
+    return server_instance;
 }
 
 int main(int argc, char **argv) {
@@ -1409,7 +1397,7 @@ int main(int argc, char **argv) {
     bool running = true;
     SDL_Event event;
     char *minecraft_options;
-    void *icon_pixels;
+    void *icon_pixels, *server_instance;
 
     parse_game_parameters(argc, argv);
 
@@ -1894,8 +1882,8 @@ int main(int argc, char **argv) {
     mod_loader_execute_on_minecraft_init(ninecraft_app, version_id);
     
 #ifdef NINECRAFT_HEADLESS
-    init_server(version_id, storage_path);
-    *(void **)((char *)ninecraft_app + 0x15c) = server; // serverInstance
+    server_instance = init_server(version_id, storage_path, "Sh0AAKocAAA=", "Server level", "Some MOTD", 19132, 10);
+    *(void **)((char *)ninecraft_app + 0x15c) = server_instance; // serverInstance
 #endif
     
     if (version_id >= version_id_0_1_0_touch) {

--- a/ninecraft/src/minecraft.c
+++ b/ninecraft/src/minecraft.c
@@ -42,6 +42,11 @@ options_set_key_t options_set_key = NULL;
 minecraft_client_get_options_t minecraft_client_get_options = NULL;
 minecraft_client_get_local_player_t minecraft_client_get_local_player = NULL;
 gui_component_fill_t gui_component_fill = NULL;
+external_level_storage_construct_t external_level_storage_construct = NULL;
+server_instance_construct_t server_instance_construct = NULL;
+server_instance_load_level_t server_instance_load_level = NULL;
+server_instance_start_server_t server_instance_start_server = NULL;
+
 
 void gui_component_draw_rect(void *gui_component, int x1, int y1, int x2, int y2, int color, int thickness) {
     if (gui_component_fill) {
@@ -331,6 +336,20 @@ uintptr_t get_ninecraftapp_internal_storage_offset(int version_id) {
     return 0;
 }
 
+size_t get_external_level_storage_size(int version_id) {
+    // TODO: Add others
+    if (version_id == version_id_0_11_1) {
+        return EXTERNALLEVELSTORAGE_SIZE_0_11_1;
+    }
+}
+
+size_t get_server_instance_size(int version_id) {
+    // TODO: Add others
+    if (version_id == version_id_0_11_1) {
+        return SERVERINSTANCE_SIZE_0_11_1;
+    }
+}
+
 void minecraft_setup_hooks(void *handle) {
     minecraft_level_generated = (minecraft_level_generated_t)android_dlsym(handle, "_ZN9Minecraft15_levelGeneratedEv");
     minecraft_tick = (minecraft_tick_t)android_dlsym(handle, "_ZN9Minecraft4tickEii");
@@ -371,4 +390,8 @@ void minecraft_setup_hooks(void *handle) {
     minecraft_client_get_options = (minecraft_client_get_options_t)android_dlsym(handle, "_ZN15MinecraftClient10getOptionsEv");
     minecraft_client_get_local_player = (minecraft_client_get_local_player_t)android_dlsym(handle, "_ZN15MinecraftClient14getLocalPlayerEv");
     gui_component_fill = (gui_component_fill_t)android_dlsym(handle, "_ZN12GuiComponent4fillEiiiii");
+    external_level_storage_construct = (external_level_storage_construct_t)android_dlsym(handle, "_ZN30ExternalFileLevelStorageSourceC1ERKSs");
+    server_instance_construct = (server_instance_construct_t)android_dlsym(handle, "_ZN14ServerInstanceC1ER18LevelStorageSource");
+    server_instance_load_level = (server_instance_load_level_t)android_dlsym(handle, "_ZN14ServerInstance9loadLevelESsSsRK13LevelSettings");
+    server_instance_start_server = (server_instance_start_server_t)android_dlsym(handle, "_ZN14ServerInstance11startServerESsii");
 }

--- a/ninecraft/src/minecraft.c
+++ b/ninecraft/src/minecraft.c
@@ -46,7 +46,7 @@ external_level_storage_construct_t external_level_storage_construct = NULL;
 server_instance_construct_t server_instance_construct = NULL;
 server_instance_load_level_t server_instance_load_level = NULL;
 server_instance_start_server_t server_instance_start_server = NULL;
-
+minecraft_client_leave_game_t minecraft_client_leave_game = NULL;
 
 void gui_component_draw_rect(void *gui_component, int x1, int y1, int x2, int y2, int color, int thickness) {
     if (gui_component_fill) {
@@ -394,4 +394,5 @@ void minecraft_setup_hooks(void *handle) {
     server_instance_construct = (server_instance_construct_t)android_dlsym(handle, "_ZN14ServerInstanceC1ER18LevelStorageSource");
     server_instance_load_level = (server_instance_load_level_t)android_dlsym(handle, "_ZN14ServerInstance9loadLevelESsSsRK13LevelSettings");
     server_instance_start_server = (server_instance_start_server_t)android_dlsym(handle, "_ZN14ServerInstance11startServerESsii");
+    minecraft_client_leave_game = (minecraft_client_leave_game_t)android_dlsym(handle, "_ZN15MinecraftClient9leaveGameEb");
 }


### PR DESCRIPTION
This PR adds a new target, `ninecraft-headless` which enables a macro that disables most GUI-related codepaths (i.e. SDL2, OpenGL) and starts up a Minecraft server instance using the built-in class for 0.11.1

Currently only support for 0.11.1 has been added, and there is no mechanism to choose level file or level name, but this is to be worked on.

Any/all feedback is appreciated. Please provide suggestions on how we should retrieve level file etc. (Should it be just `world`? Should storage path be bypassed?)